### PR TITLE
enable port forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,8 @@ Vagrant.configure("2") do |config|
   config.vm.define "www1" do |v|
     v.vm.hostname = "www1"
     v.vm.network :private_network, ip: "172.16.1.10"
+    v.vm.network "forwarded_port", guest: 80, host: 8080
+    v.vm.network "forwarded_port", guest: 443, host: 8443
     v.vm.provision "shell", inline: provisioning_script, privileged: false
   end
 


### PR DESCRIPTION
When developing locally it's helpful to be able to access 80 and 443 on the webserver. This PR sets up port forwarding with the following mapping:

localhost:8443 => www1:443
localhost:8080 => www1:80
