### PR TITLE
add missing tmp directories for drupal

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -58,6 +58,32 @@ execute '/usr/local/bin/deploy_site' do
   creates '/home/drupal/scale-drupal'
 end
 
+# Ensure existance of drupal directories
+%w{
+ /home/drupal/scale-drupal/httpdocs
+ /home/drupal/scale-drupal/httpdocs/sites
+ /home/drupal/scale-drupal/httpdocs/sites/default
+}.each do |tmpdir|
+  directory tmpdir do
+    owner 'root'
+    group 'root'
+    mode '0755'
+  end
+end
+
+# Ensure existance of tmp directories required by drupal
+%w{
+ /home/drupal/scale-drupal/httpdocs/sites/default/files
+ /home/drupal/scale-drupal/httpdocs/sites/default/files/css
+ /home/drupal/scale-drupal/db
+}.each do |tmpdir|
+  directory tmpdir do
+    owner 'root'
+    group 'apache'
+    mode '0775'
+  end
+end
+
 template '/home/drupal/scale-drupal/httpdocs/sites/default/settings.php' do
   owner 'root'
   group 'apache'


### PR DESCRIPTION
Drupal requires these temporary paths for user uploads of images and other files attached to documents.
