### PR TITLE
clone static files from legacy sites

### DIFF
--- a/cookbooks/scale_apache/files/default/deploy_legacy_sites
+++ b/cookbooks/scale_apache/files/default/deploy_legacy_sites
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd /home/
+if [ -d /home/webroot ]; then
+  cd /home/webroot/
+  git pull
+else
+  git clone https://github.com/socallinuxexpo/scale-legacy-web.git /home/webroot/
+fi

--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -52,10 +52,21 @@ cookbook_file '/usr/local/bin/deploy_site' do
   mode '0755'
 end
 
+cookbook_file '/usr/local/bin/deploy_legacy_sites' do
+  source 'deploy_legacy_sites'
+  owner 'root'
+  group 'root'
+  mode '0755'
+end
+
 # We don't want to deploy the site on every single run,
 # but if we don't *have* the site yet, deploy it
 execute '/usr/local/bin/deploy_site' do
   creates '/home/drupal/scale-drupal'
+end
+
+execute '/usr/local/bin/deploy_legacy_sites' do
+  creates '/home/webroot/'
 end
 
 # Ensure existance of drupal directories
@@ -63,6 +74,7 @@ end
  /home/drupal/scale-drupal/httpdocs
  /home/drupal/scale-drupal/httpdocs/sites
  /home/drupal/scale-drupal/httpdocs/sites/default
+ /home/webroot/
 }.each do |tmpdir|
   directory tmpdir do
     owner 'root'


### PR DESCRIPTION
Added scale-legacy-web to the repos being cloned.  This mostly fixes #5.
The only files not yet in the repo are scale7x audio as thats 2GB of content and seems like an odd fit for git.  Might look at moving that to a CDN somewhere.
