### PR TITLE
add tmpwatch to clean up /tmp files over 72 hours old

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -137,6 +137,14 @@ file '/etc/drupal_secrets' do
   mode '0600'
 end
 
+node.default['fb_systemd']['tmpfiles']['/tmp'] = {
+  'type' => 'D',
+  'mode' => '1777',
+  'uid' => 'root',
+  'gid' => 'root',
+  'age' => '72h',
+}
+
 node.default['fb_cron']['jobs']['drupal_backup'] = {
   'time' => '30 0,12 * * *',
   'command' => '/usr/local/bin/backup-drupal-static.sh'


### PR DESCRIPTION
add tmpwatch to clean up /tmp files over 72 hours old
