### PR TITLE
set correct domain name

### DIFF
--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -160,7 +160,7 @@ node.default['scale_postfix']['main.cf']['alias_maps'] <<
 {
   'mydestination' =>
     'lists.linuxfests.org, $myhostname, localhost.$mydomain, localhost',
-  'mydomain' => 'lists.linuxfests.org',
+  'mydomain' => 'linuxfests.org',
 }.each do |conf, val|
   node.default['scale_postfix']['main.cf'][conf] = val
 end


### PR DESCRIPTION
some mail was failing to deliver as the remote servers were validating the host mentioned in the EHLO. With mydomain=lists.linuxfests.org that was resulting in   

EHLO lists.lists.linuxfests.org
