### PR TITLE
explicitly set s3 region to work around timeout bug in boto

### DIFF
--- a/cookbooks/scale_apache/templates/default/backup-drupal-static.sh.erb
+++ b/cookbooks/scale_apache/templates/default/backup-drupal-static.sh.erb
@@ -13,7 +13,7 @@ echo "Starting backup...."
 tar cfz $TMPFILE/${TARGET} -C /home/drupal/scale-drupal/httpdocs/sites/default/ files
 
 echo "Uploading backup...."
-s3put --access_key ${S3KEY} --secret_key ${S3SECRET} --bucket ${BUCKET} --prefix ${TMPFILE} --key_prefix static/$DATE/ ${TMPFILE}/${TARGET}
+s3put --region=us-east-1 --access_key ${S3KEY} --secret_key ${S3SECRET} --bucket ${BUCKET} --prefix ${TMPFILE} --key_prefix static/$DATE/ ${TMPFILE}/${TARGET}
 
 if [ $? -eq 0 ]; then
   rm "${TMPFILE}/${TARGET}"

--- a/cookbooks/scale_mailman/templates/default/backup-mailman.sh.erb
+++ b/cookbooks/scale_mailman/templates/default/backup-mailman.sh.erb
@@ -16,7 +16,7 @@ echo "Uploading backup...."
 
 for type in archives configs
 do
-  s3put --access_key ${S3KEY} --secret_key ${S3SECRET} --bucket ${BUCKET} --prefix ${TMPFILE} --key_prefix ${type}/$DATE/ ${TMPFILE}/mailman-${type}_${HOSTNAME}_${TIME}.tar.gz
+  s3put --region=us-east-1 --access_key ${S3KEY} --secret_key ${S3SECRET} --bucket ${BUCKET} --prefix ${TMPFILE} --key_prefix ${type}/$DATE/ ${TMPFILE}/mailman-${type}_${HOSTNAME}_${TIME}.tar.gz
 
   if [ $? -eq 0 ]; then
     echo "Upload of mailman-${type} complete";


### PR DESCRIPTION
Looks like we're intermittently hitting https://github.com/boto/boto/issues/2207 in our backup scripts.  Setting the region seems to mitigate the issue.
