### PR TITLE
dont setup datadog in Vagrant

### DIFF
--- a/cookbooks/fb_init/recipes/default.rb
+++ b/cookbooks/fb_init/recipes/default.rb
@@ -44,7 +44,7 @@ include_recipe 'scale_postfix'
 include_recipe 'scale_sudo'
 # HERE: ntp
 include_recipe 'fb_motd'
-if !node.vagrant?
+unless node.vagrant?
   include_recipe 'scale_datadog'
   include_recipe 'scale_datadog::dd-handler'
 end


### PR DESCRIPTION
We generally don't need to monitor everyone's local dev environments.
