### PR TITLE
add new list for openinfra day team

### DIFF
--- a/cookbooks/scale_mailman/attributes/default.rb
+++ b/cookbooks/scale_mailman/attributes/default.rb
@@ -34,5 +34,6 @@ default['scale_mailman']['lists'] = [
     "scale-community",
     "scale-planning",
     "scale-volunteers",
-    "tech"
+    "tech",
+    "open-infra-day"
 ]


### PR DESCRIPTION
[Open Infrastructure Day](http://scale.opensourceinfra.org/) is going to be held at SCALE this year. They asked if we could help them with a planning mailing list.  

Mailman commands have been run, all thats missing is this commit which adds the postfix configs.
