### PR TITLE
Various improvements to management and testing

### DIFF
--- a/cookbooks/scale_chef_client/files/default/taste-untester
+++ b/cookbooks/scale_chef_client/files/default/taste-untester
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Copyright 2013-present Facebook
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CONFLINK='/etc/chef/client.rb'
+PRODCONF='/etc/chef/client-prod.rb'
+CERTLINK='/etc/chef/client.pem'
+PRODCERT='/etc/chef/client-prod.pem'
+STAMPFILE='/etc/chef/test_timestamp'
+MYSELF=$0
+DRYRUN=0
+DEBUG=0
+
+debug() {
+  [ "$DEBUG" -eq 1 ] && echo $*
+}
+
+set_server_to_prod() {
+  ME=$(basename $MYSELF)
+  if [ -s $STAMPFILE ]; then
+    kill -- -$(cat $STAMPFILE)
+  fi
+  rm -f $CONFLINK
+  ln -s $PRODCONF $CONFLINK
+  # Legacy FB stuff, will go away
+  if [ -h $CERTLINK ]; then
+    rm $CERTLINK
+    ln -s $PRODCERT $CERTLINK
+  fi
+  rm -f $STAMPFILE
+  logger -p user.warning -t $ME Reverted to production Chef.
+  if [ -e '/usr/bin/wall' ]; then
+    echo "Reverted $(hostname) to production Chef." | wall
+  fi
+}
+
+check_server() {
+  if [ ! -h $CONFLINK ]; then
+    return
+  fi
+  current_config=$(readlink $CONFLINK)
+  if [ "$current_config" = $PRODCONF ]; then
+    if [ -f "$STAMPFILE" ]; then
+      rm -f $STAMPFILE
+    fi
+    return
+  fi
+
+  now=$(date +%s)
+  if [ "$(uname)" = 'Darwin' ]; then
+    stamp_time=$(stat -f "%m" -t "%z" $STAMPFILE)
+    stamp=$(date -r $stamp_time)
+  else
+    stamp=$(stat -c %y $STAMPFILE)
+    stamp_time=$(date +%s -d "$stamp")
+  fi
+
+  debug "$now vs $stamp_time"
+  if [ "$now" -gt "$stamp_time" ]; then
+    if [ $DRYRUN -eq 0 ]; then
+      set_server_to_prod
+    else
+      echo "DRYRUN: Would return server to prod"
+    fi
+  fi
+}
+
+while getopts 'dn' opt; do
+  case "$opt" in
+    d)
+      DEBUG=1
+      ;;
+    n)
+      DRYRUN=1
+      ;;
+  esac
+done
+
+check_server

--- a/scripts/stop_chef_lib.sh
+++ b/scripts/stop_chef_lib.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+CHEF_CURRENT_OUT='/var/chef/outputs/chef.cur.out'
+SKIP_SELF=0
+PS="ps -e -o pid,pgid,sess,command"
+
+get_chefctl_procs() {
+  out=$($PS | grep -v chefctl_solo | grep chefctl)
+  if [ "$SKIP_SELF" -eq 1 ]; then
+    pgid=$($PS | grep $$ | awk '{print $2}' | uniq)
+    out=$(echo "$out" | grep -v "$pgid")
+  fi
+  echo "$out" | awk '{print $1}' | xargs
+}
+
+get_chefclient_procs() {
+  opts=''
+  if [ "$OS" = 'Darwin' ]; then
+    opts='-f'
+  fi
+  pgrep $opts chef-client
+}
+
+stop_or_wait_for_chef() {
+  [ "$1" = 'skip_self' ] && SKIP_SELF=1
+
+  # Is Chef even running?
+  [ -z "$(get_chefctl_procs)" ] && return 0
+
+  if [ ! -e $CHEF_CURRENT_OUT ]; then
+    return 0
+  fi
+
+  # If it is running ...
+  # If there is only one line, then we are in the "sleep for $splay"
+  # phase (the first line is printed by client.rb), so it's safe to kill it.
+  # There's a VERY VERY slight race condition here in that we could look at the
+  # file and then the splay ends and it starts, but it takes more than a second
+  # for authentication and synchronization to happen, so even if that happens,
+  # we will kill the run before it's done anything useful.
+
+  # If "skip_self" flag is passed we take care to kill *other* chefctl runs
+  # or properly wait for them to finish.
+
+  lines=$(wc -l $CHEF_CURRENT_OUT | awk '{print $1}')
+  procs=$(get_chefctl_procs)
+  if [ "$lines" -lt 3 ] ; then
+    if [ -n "$procs" ]; then
+      kill $procs 2> /dev/null
+      sleep 1
+      kill $procs 2> /dev/null
+      kill -9 $procs 2> /dev/null
+    fi
+    pkill chef-client 2> /dev/null
+    sleep 1
+    pkill -9 chef-client 2> /dev/null
+  else
+    num_chefctl_procs=$(echo "$procs" | wc -w)
+    # Each chefctl instance can show up as 1-3 processes. So best case, we'll
+    # only queue 5 runs. Worst case, we'll queue 15 runs.
+    if [ "$num_chefctl_procs" -lt 15 ] ; then
+      echo -n 'Waiting for other Chef runs to complete '
+      while true; do
+        [ -z "$(get_chefclient_procs)" ] && break
+        echo -n '.'
+        sleep 5
+      done
+      # chef-client is gone, kill any left waiting chefctls
+      procs=$(get_chefctl_procs)
+      if [ -n "$procs" ]; then
+        kill $(get_chefctl_procs) >/dev/null 2>/dev/null
+      fi
+      echo ' done.'
+    else
+      echo 'Several Chef runs already queued. Not queueing any more.'
+      exit 0
+    fi
+  fi
+  return 0
+}

--- a/scripts/stop_chef_temporarily
+++ b/scripts/stop_chef_temporarily
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+. stop_chef_lib
+
+OVERRIDE_FILE=/var/chef/cron.default.override
+
+[ $EUID -eq 0 ] || {
+  echo "Ray, when someone asks you if you're a god, you say YES!"
+  echo "(you must be root to do this)"
+  exit 1
+}
+
+#
+# These are functions other chef scripts may want to utilize
+#
+
+
+get_chefctl_procs() {
+  out=$($PS | grep -v chefctl_solo | grep chefctl)
+  if [ "$SKIP_SELF" -eq 1 ]; then
+    pgid=$($PS | grep $$ | awk '{print $2}' | uniq)
+    out=$(echo "$out" | grep -v "$pgid")
+  fi
+  echo "$out" | awk '{print $1}' | xargs
+}
+
+get_chefclient_procs() {
+  opts=''
+  if [ "$OS" = 'Darwin' ]; then
+    opts='-f'
+  fi
+  pgrep $opts chef-client
+}
+
+stop_or_wait_for_chef() {
+  [ "$1" = 'skip_self' ] && SKIP_SELF=1
+
+  # Is Chef even running?
+  [ -z "$(get_chefctl_procs)" ] && return 0
+
+  if [ ! -e $CHEF_CURRENT_OUT ]; then
+    return 0
+  fi
+
+  # If it is running ...
+  # If there is only one line, then we are in the "sleep for $splay"
+  # phase (the first line is printed by client.rb), so it's safe to kill it.
+  # There's a VERY VERY slight race condition here in that we could look at the
+  # file and then the splay ends and it starts, but it takes more than a second
+  # for authentication and synchronization to happen, so even if that happens,
+  # we will kill the run before it's done anything useful.
+
+  # If "skip_self" flag is passed we take care to kill *other* chefctl runs
+  # or properly wait for them to finish.
+
+  lines=$(wc -l $CHEF_CURRENT_OUT | awk '{print $1}')
+  procs=$(get_chefctl_procs)
+  if [ "$lines" -lt 3 ] ; then
+    if [ -n "$procs" ]; then
+      kill $procs 2> /dev/null
+      sleep 1
+      kill $procs 2> /dev/null
+      kill -9 $procs 2> /dev/null
+    fi
+    pkill chef-client 2> /dev/null
+    sleep 1
+    pkill -9 chef-client 2> /dev/null
+  else
+    num_chefctl_procs=$(echo "$procs" | wc -w)
+    # Each chefctl instance can show up as 1-3 processes. So best case, we'll
+    # only queue 5 runs. Worst case, we'll queue 15 runs.
+    if [ "$num_chefctl_procs" -lt 15 ] ; then
+      echo -n 'Waiting for other Chef runs to complete '
+      while true; do
+        [ -z "$(get_chefclient_procs)" ] && break
+        echo -n '.'
+        sleep 5
+      done
+      # chef-client is gone, kill any left waiting chefctls
+      procs=$(get_chefctl_procs)
+      if [ -n "$procs" ]; then
+        kill $(get_chefctl_procs) >/dev/null 2>/dev/null
+      fi
+      echo ' done.'
+    else
+      echo 'Several Chef runs already queued. Not queueing any more.'
+      exit 0
+    fi
+  fi
+  return 0
+}
+
+
+help() {
+  echo "
+Usage: $0 [options]
+
+Attempts to safely stop or wait for any active chef runs and then prevent
+future runs for the time period specified (1 hour by default). We use the
+override file built in to chefctl.sh ($OVERRIDE_FILE).
+
+You can re-enable chef at any time by deleting $OVERRIDE_FILE
+
+Options:
+  -h
+      Print help
+
+  -r <reason>
+      Provide a custom message explaining why you stopped chef.
+
+  -t <hours>
+      Stop for <hours> hours, default is 1 hour even if option is not
+      specified.
+"
+}
+
+stop() {
+  hours=$1
+  reason=$2
+
+  # Try to let people know who did this
+  msg="$(date) USER=$USER SUDO_USER=$SUDO_USER REASON=$reason"
+  echo "$msg" >> $OVERRIDE_FILE
+
+  # We remove the override when it is 1 hour old so actually touch the file
+  # one less hour than requested. Also, macs don't use coreutils touch so
+  # make it work.
+  if [ $hours -eq 1 ]; then
+    # Nice and easy
+    touch $OVERRIDE_FILE
+    stop_or_wait_for_chef
+    echo 'Chef disabled for 1 hour.'
+  else
+    realhours=$(($hours-1))
+    touch -d "now + $realhours hours" $OVERRIDE_FILE
+    stop_or_wait_for_chef
+    echo "Chef disabled for $hours hours."
+  fi
+}
+
+# default
+thours=1
+reason='none'
+
+while getopts 'hr:t:' opt; do
+  case "$opt" in
+    h)
+      help
+      exit 0
+      ;;
+    r)
+      reason="$OPTARG"
+      ;;
+    t)
+      thours="$OPTARG"
+      ;;
+    *)
+      help
+      exit 1
+      ;;
+  esac
+done
+
+if [ $thours -lt 1 ]; then
+  echo "Invalid value: \"$thours\" hours is nonsensical, cowardly refusing"
+  help
+  exit 1
+fi
+
+stop "$thours" "$reason"


### PR DESCRIPTION
- All chef runs are now logged in /var/chef/outputs
- There's now a way to pause cron'd chef runs
- taste-untester now runs
- chefctl now updates roles and scripts in 'vagrant' mode
- chefctl now locks

closes #53
