### PR TITLE
route mail via mailgun

### DIFF
--- a/cookbooks/scale_postfix/attributes/default.rb
+++ b/cookbooks/scale_postfix/attributes/default.rb
@@ -1,7 +1,7 @@
 default['scale_postfix'] = {
   'aliases' => {
     'postmaster' => 'root',
-    'MAILER-DAEON' => 'postmaster',
+    'MAILER-DAEON' => 'postmaster'
   },
   'main.cf' => {
     'soft_bounce' => 'no',
@@ -17,7 +17,7 @@ default['scale_postfix'] = {
       '$myhostname, localhost.$mydomain, localhost',
     'unknown_local_recipient_reject_code' => '550',
     'alias_maps' => [
-      'hash:/etc/postfix/aliases',
+      'hash:/etc/postfix/aliases'
     ],
     'alias_database' => 'hash:/etc/postfix/aliases',
     'debug_peer_level' => '2',
@@ -32,5 +32,12 @@ default['scale_postfix'] = {
     'debugger_command' =>
       'PATH=/bin:/usr/bin:/usr/local/bin:/usr/X11R6/bin' +
       'ddd $daemon_directory/$process_name $process_id & sleep 5',
-  },
+  }
 }
+
+if File.exists?('/etc/postfix/sasl_passwd.db')
+  default['scale_postfix']['main.cf']['smtp_sasl_auth_enable'] = 'yes'
+  default['scale_postfix']['main.cf']['relayhost'] = 'smtp.mailgun.org'
+  default['scale_postfix']['main.cf']['smtp_sasl_security_options'] = 'noanonymous'
+  default['scale_postfix']['main.cf']['smtp_sasl_password_maps'] = 'hash:/etc/postfix/sasl_passwd'
+end

--- a/cookbooks/scale_postfix/recipes/default.rb
+++ b/cookbooks/scale_postfix/recipes/default.rb
@@ -42,7 +42,6 @@ file '/etc/postfix/sasl_passwd.db' do
   owner 'root'
   group 'root'
   mode '0600'
-  notifies :restart, 'service[postfix]', :immediately
 end
 
 service 'postfix' do

--- a/cookbooks/scale_postfix/recipes/default.rb
+++ b/cookbooks/scale_postfix/recipes/default.rb
@@ -10,6 +10,8 @@
 pkgs = %w{
   postfix
   postfix-perl-scripts
+  cyrus-sasl-plain
+  cyrus-sasl-md5
 }
 
 package pkgs do
@@ -19,7 +21,7 @@ end
 template '/etc/postfix/main.cf' do
   owner 'root'
   group 'root'
-  mode  '0644'
+  mode '0644'
   notifies :restart, 'service[postfix]', :immediately
 end
 
@@ -27,12 +29,19 @@ template '/etc/postfix/aliases' do
   source 'aliases.erb'
   owner 'root'
   group 'root'
-  mode  '0644'
+  mode '0644'
   notifies :run, 'execute[newaliases]', :immediately
 end
 
 execute 'newaliases' do
   action :nothing
+  notifies :restart, 'service[postfix]', :immediately
+end
+
+file '/etc/postfix/sasl_passwd.db' do
+  owner 'root'
+  group 'root'
+  mode '0600'
   notifies :restart, 'service[postfix]', :immediately
 end
 


### PR DESCRIPTION
### What does this PR do?

Once merged our postfix cookbook will support routing outbound mail through third parties, such as mailgun.org.  Whether postfix will send direct or relay through mailgun will currently depend on if the mailgun secrets have been deployed at /etc/postfix/sasl_passwd.db

We opted for mailgun as the provider in this case as our agreement with Rackspace includes 50K messages per month.   At this time I only plan to enable this on scale-www1 and scale-reg1, as they have fairly low volume.  

We should review if Mailman and PHPlist would benefit from this in the future and consider standardizing, once we have a sense of how many emails we send each month.

### Motivation

Many users have been reporting that mail from our CFP and other systems is not reaching them, or is ending up flagged as spam.  By routing through an established mail provider we believe we'll have better success in reaching our users.

### Testing Guidelines

- Upload scale-secrets/common/sasl_passwd.db to /etc/postfix/ on the taste-tester role you wish to validate with OR your local vagrant vm.
- Run either taste-taster or chefctl as appropriate.
- Send yourself an email via CLI tools such as mailx. (eg echo "testing all the things"| mail -r <from-email> -s "test subject" <to-email>
- Use the password reset function in drupal to have it send you an email.  
- Once both emails have been received validate the headers include DMARC, DKIM, and SPF passes; as well as X-Mailgun-* headers.
