### PR TITLE
only manage perms on sasl if the file exists

### DIFF
--- a/cookbooks/scale_postfix/recipes/default.rb
+++ b/cookbooks/scale_postfix/recipes/default.rb
@@ -42,6 +42,7 @@ file '/etc/postfix/sasl_passwd.db' do
   owner 'root'
   group 'root'
   mode '0600'
+  only_if { File.exists?('/etc/postfix/sasl_passwd.db') }
 end
 
 service 'postfix' do


### PR DESCRIPTION
### What does this PR do?

Address feedback on #89, such that we never create the sasl_passwd file and only manage perms on it if it already exists.

### Motivation

Properly gate routing via mailgun on the presence of our creds.

### Testing Guidelines

Run chef on a host without sasl_passwd, confirm its not present after the chef run completes.

### Additional Notes

Once merged we need to delete /etc/postfix/sasl_passwd.db from any hosts we dont want routing through mailgun in test or prod.