### PR TITLE
allow dd-agent to use sudo with /bin/find and /usr/bin/find

### DIFF
--- a/cookbooks/fb_init/recipes/site_settings.rb
+++ b/cookbooks/fb_init/recipes/site_settings.rb
@@ -44,7 +44,7 @@ node.default['scale_datadog']['monitors']['postfix'] = {
 }
 
 node.default['scale_sudo']['users']['dd-agent'] =
-  'ALL=(ALL) NOPASSWD:/usr/bin/find /var/spool/postfix/ -type f'
+  'ALL=(ALL) NOPASSWD:/usr/bin/find /var/spool/postfix/ -type f, /bin/find /var/spool/postfix/ -type f'
 
 d = {}
 if File.exists?('/etc/lists_secrets')


### PR DESCRIPTION
### What does this PR do?

Allow dd-agent to use sudo with /bin/find in addition to the existing entry for /usr/bin/find.

### Motivation

Seems like our postfix queue metrics haven't been received consistently, as sudo was failing.

### Testing Guidelines

Confirm postfix metrics are present in Datadog via [metrics explorer](https://app.datadoghq.com/metric/explorer?live=true&page=0&is_auto=false&tile_size=m&exp_metric=postfix.queue.size&exp_scope=&exp_agg=avg&exp_row_type=metric)