### PR TITLE
Make sure we reload the firewall on package upgrade

### DIFF
--- a/cookbooks/fb_iptables/recipes/default.rb
+++ b/cookbooks/fb_iptables/recipes/default.rb
@@ -25,10 +25,10 @@ services = ['iptables', 'ip6tables']
 iptables_rules = '/etc/sysconfig/iptables'
 ip6tables_rules = '/etc/sysconfig/ip6tables'
 
-packages.each do |pkg|
-  package pkg do
-    action :upgrade
-  end
+package packages do
+  action :upgrade
+  notifies :restart, 'execute[reload iptables]'
+  notifies :restart, 'execute[reload ip6tables]'
 end
 services.each do |svc|
   service svc do


### PR DESCRIPTION
The packages loads some default rules for some reason, make sure we
reload our own rules at the end of the run.

I will push this upstream as well.