### PR TITLE
scale_yum: use current epel package

### DIFF
--- a/cookbooks/scale_yum/recipes/default.rb
+++ b/cookbooks/scale_yum/recipes/default.rb
@@ -1,8 +1,10 @@
 # vim:shiftwidth=2:expandtab
 
-remote_file "#{Chef::Config['file_cache_path']}/epel-release-7-8.noarch.rpm" do
+epel_pkg = 'epel-release-7-9.noarch.rpm'
+
+remote_file "#{Chef::Config['file_cache_path']}/#{epel_pkg}" do
   not_if { File.exists?('/etc/yum.repos.d/epel.repo') }
-  source 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm'
+  source "http://dl.fedoraproject.org/pub/epel/7/x86_64/e/#{epel_pkg}"
   owner 'root'
   group 'root'
   mode '0644'
@@ -11,6 +13,6 @@ end
 
 package 'epel-release' do
   not_if { File.exists?('/etc/yum.repos.d/epel.repo') }
-  source "#{Chef::Config['file_cache_path']}/epel-release-7-8.noarch.rpm"
+  source "#{Chef::Config['file_cache_path']}/#{epel_pkg}"
 end
 


### PR DESCRIPTION
Fix scale_yum to use the current EPEL package and refactor a bit. This fixes bootstrap in Vagrant from scratch.
