### PR TITLE
Update to EPEL 7-9

### DIFF
--- a/cookbooks/scale_yum/recipes/default.rb
+++ b/cookbooks/scale_yum/recipes/default.rb
@@ -1,6 +1,6 @@
 # vim:shiftwidth=2:expandtab
 
-epel_pkg = 'epel-release-7-9.noarch.rpm'
+epel_pkg = 'epel-release-7-10.noarch.rpm'
 
 remote_file "#{Chef::Config['file_cache_path']}/#{epel_pkg}" do
   not_if { File.exists?('/etc/yum.repos.d/epel.repo') }


### PR DESCRIPTION
*Note: Please remember to review our [Contribution Guidelines](https://github.com/socallinuxexpo/scale-chef/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fixes the scale_yum recipe. EPEL 7-9 packages are no longer available on fedoraproject.org updating to 7-10 

### Motivation

Make chef runs pass.

### Testing Guidelines

An overview on [testing](https://github.com/socallinuxexpo/scale-chef/blob/master/CONTRIBUTING.md)
is available in our contribution guidelines.
