### PR TITLE
Use fastly client ip instead of REMOTE_ADDR

### DIFF
--- a/cookbooks/scale_drupal/templates/default/settings.php.erb
+++ b/cookbooks/scale_drupal/templates/default/settings.php.erb
@@ -472,3 +472,7 @@ $conf['environment_indicator_overwritten_fixed'] = FALSE;
 # HTTPS
 $conf['https'] = TRUE;
 
+# Use Fastly Client IP as remote address when head present
+if (isset($_SERVER['HTTP_FASTLY_CLIENT_IP'])) {
+  $_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_FASTLY_CLIENT_IP'];
+}


### PR DESCRIPTION
### What does this PR do?

overrides REMOTE_ADDR with the contents of HTTP_FASTLY_CLIENT_IP if that header is present.

### Motivation

We'd like to use fastly for a CDN to improve sit performance.

Drupal and Hashcash take various actions based on end user ip which it reads from REMOTE_ADDR.
When we're routing through CDNs like fastly, this is not the case and the remote IP is the IP of Fastly's edge server.

To work around this lets add logic that overrides REMOTE_ADDR if the HTTP_FASTLY_CLIENT_IP header is present.
