### PR TITLE
update to datadog agent v6

### DIFF
--- a/cookbooks/scale_datadog/README.md
+++ b/cookbooks/scale_datadog/README.md
@@ -12,11 +12,11 @@ Attributes
 Usage
 -----
 ### scale_datadog::default
-The `default` recipe sets up the DataDog agent - installing the necessary packages, writing config files and starting the service.
+The `default` recipe sets up the Datadog agent - installing the necessary packages, writing config files and starting the service.
 
-`/etc/dd-agent/datadog.conf' is populated with key-value pairs from `node['scale_datadog']['config']`.
+`/etc/datadog-agent/datadog.yaml' is populated with key-value pairs from `node['scale_datadog']['config']`.
 
 Individual monitors can be setup in `node['scale_datadog']['monitors']` - each entry in there will become a YAML file in `/etc/dd-agent/conf.d` - and all yaml files in there not configured by this cookbook will be deleted.
 
 ### scale_datadog::dd-handler
-Sets up the DataDog chef-handler.
+Sets up the Datadog chef-handler.

--- a/cookbooks/scale_datadog/attributes/default.rb
+++ b/cookbooks/scale_datadog/attributes/default.rb
@@ -6,9 +6,9 @@ default['scale_datadog'] = {
     'api_key' => nil,
     'application_key' => nil,
     'log_to_syslog' => 'no',
-    'logs_enabled' => 'true',
+    'logs_enabled' => true,
     'process_config' => {
-      'enabled':'true',
+      'enabled': true,
     },
   },
   'monitors' => {},

--- a/cookbooks/scale_datadog/attributes/default.rb
+++ b/cookbooks/scale_datadog/attributes/default.rb
@@ -6,6 +6,10 @@ default['scale_datadog'] = {
     'api_key' => nil,
     'application_key' => nil,
     'log_to_syslog' => 'no',
+    'logs_enabled' => 'true',
+    'process_config' => {
+      'enabled':'true',
+    },
   },
   'monitors' => {},
 }

--- a/cookbooks/scale_datadog/files/default/datadog.repo
+++ b/cookbooks/scale_datadog/files/default/datadog.repo
@@ -1,5 +1,5 @@
 [datadog]
 name=Datadog
-baseurl=http://yum.datadoghq.com/rpm/x86_64/
+baseurl=https://yum.datadoghq.com/stable/6/x86_64/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/DATADOG_RPM_KEY.public

--- a/cookbooks/scale_datadog/providers/monitor_configs.rb
+++ b/cookbooks/scale_datadog/providers/monitor_configs.rb
@@ -5,7 +5,7 @@ end
 use_inline_resources
 
 action :update do
-  Dir.glob('/etc/dd-agent/conf.d/*.yaml').each do |f|
+  Dir.glob('/etc/datadog-agent/conf.d/*.yaml').each do |f|
     basename = ::File.basename(f, '.yaml')
     next if node['scale_datadog']['monitors'].keys.include?(basename)
     file f do
@@ -14,7 +14,7 @@ action :update do
   end
 
   node['scale_datadog']['monitors'].to_hash.each do |monitor, config|
-    template "/etc/dd-agent/conf.d/#{monitor}.yaml" do
+    template "/etc/datadog-agent/conf.d/#{monitor}.yaml" do
       source 'monitor.yaml.erb'
       owner 'dd-agent'
       group 'root'

--- a/cookbooks/scale_datadog/recipes/default.rb
+++ b/cookbooks/scale_datadog/recipes/default.rb
@@ -23,15 +23,15 @@ package 'datadog-agent' do
   notifies :restart, 'service[datadog-agent]'
 end
 
-directory '/etc/dd-agent' do
-  owner 'root'
-  group 'root'
+directory '/etc/datadog-agent' do
+  owner 'dd-agent'
+  group 'dd-agent'
   mode '0755'
 end
 
-template '/etc/dd-agent/datadog.conf' do
-  source 'datadog.conf.erb'
-  owner 'root'
+template '/etc/datadog-agent/datadog.yaml' do
+  source 'datadog.yaml.erb'
+  owner 'dd-agent'
   group 'dd-agent'
   mode '0640'
   notifies :restart, 'service[datadog-agent]'

--- a/cookbooks/scale_datadog/templates/default/datadog.conf.erb
+++ b/cookbooks/scale_datadog/templates/default/datadog.conf.erb
@@ -1,6 +1,0 @@
-# This file is managed by Chef, do not edit!
-
-[Main]
-<% node['scale_datadog']['config'].each do |key, val| -%>
-<%=  key %>: <%= val %>
-<% end -%>

--- a/cookbooks/scale_datadog/templates/default/datadog.yaml.erb
+++ b/cookbooks/scale_datadog/templates/default/datadog.yaml.erb
@@ -1,0 +1,3 @@
+# This file is managed by Chef, do not edit!
+
+<%= node['scale_datadog']['config'].to_hash.to_yaml %>


### PR DESCRIPTION
### What does this PR do?

Update to datadog-agent 6.x

### Motivation

dd-agent 5.x is EOL and 6.x gives us log management and process monitoring