### PR TITLE
use hashrocket for assignment

### DIFF
--- a/cookbooks/scale_datadog/attributes/default.rb
+++ b/cookbooks/scale_datadog/attributes/default.rb
@@ -8,7 +8,7 @@ default['scale_datadog'] = {
     'log_to_syslog' => 'no',
     'logs_enabled' => true,
     'process_config' => {
-      'enabled': true,
+      'enabled' => true,
     },
   },
   'monitors' => {},


### PR DESCRIPTION
Apparently we use chef 14 on some hosts and 12 on others.  The hashrocket assignment seems to work in 12 and 14, : only works on the hosts running 14. Joy for consistently.