### PR TITLE
[renew certs] Make quieter

### DIFF
--- a/cookbooks/scale_apache/files/default/renew_certs.sh
+++ b/cookbooks/scale_apache/files/default/renew_certs.sh
@@ -18,4 +18,4 @@
 #  -w /var/www/html -d lists.socallinuxexpo.org,lists.linuxfests.org
 #  --webroot -n --rsa-key-size 4096
 
-certbot renew --post-hook "service httpd restart" -q --rsa-key-size 4096
+certbot renew --post-hook "systemctl restart httpd" -q --rsa-key-size 4096


### PR DESCRIPTION
Don't let service throw warnings about using systemctl, just use
systemctl directly.


