### PR TITLE
fb_init: fix tier lookup logic

### DIFF
--- a/cookbooks/fb_init/attributes/default.rb
+++ b/cookbooks/fb_init/attributes/default.rb
@@ -9,8 +9,8 @@ if pieces.size == 3
 else
   env = 'prod'
 end
-org = pieces[0]
-tier = pieces[1]
+org = pieces[1]
+tier = pieces[0]
 
 default['tier'] = tier
 default['org'] = org


### PR DESCRIPTION
Unbreak chef on lists (previous logic was setting the role to 'scale', which does not exist)