### PR TITLE
Update fb_apache to latest upstream

### DIFF
--- a/cookbooks/fb_apache/README.md
+++ b/cookbooks/fb_apache/README.md
@@ -4,7 +4,6 @@ Installs and configures Apache
 
 Requirements
 ------------
-Currently only tested on Linux
 
 Attributes
 ----------
@@ -16,11 +15,15 @@ Attributes
 * node['fb_apache']['modules_directory']
 * node['fb_apache']['modules_mapping']
 * node['fb_apache']['module_packages']
+* node['fb_apache']['extra_configs']
 
 Usage
 -----
 ### Packages
-My default `fb_apache` will install and keep up to date the apache and mod_ssl packages as relevant for your distribution. If you'd prefer to do this on your own then you can set `node['fb_apache']['manage_packages']` to false.
+My default `fb_apache` will install and keep up to date the `apache` and
+`mod_ssl` packages as relevant for your distribution. If you'd prefer to do
+this on your own then you can set `node['fb_apache']['manage_packages']` to
+`false`.
 
 For modules, we keep a mapping of the package required for modules in
 `node['fb_apache']['module_packages']`. If `manage_packages` is enabled, we will
@@ -29,7 +32,10 @@ install the relevant packages for any modules you enable in
 attempt to start apache.
 
 ### Sites / VirtualHosts
-The `node['fb_apache']['sites']` hash configures virtual hosts. All virtual hosts are kept in a single file called `fb_apache_sites.cfg` in a directory relevant to your distribution. In general, it's a 1;1 mapping of the apache syntax to a hash. So for example:
+The `node['fb_apache']['sites']` hash configures virtual hosts. All virtual
+hosts are kept in a single file called `fb_apache_sites.cfg` in a directory
+relevant to your distribution. In general, it's a 1:1 mapping of the apache
+syntax to a hash. So for example:
 
 ```ruby
 node.default['fb_apache']['sites']['*:80'] = {
@@ -49,7 +55,8 @@ Will produce:
 </VirtualHost>
 ```
 
-If the value of the hash is an Array, then it's assumed it's a key that can be repeated. So for example:
+If the value of the hash is an `Array`, then it's assumed it's a key that can
+be repeated. So for example:
 
 ```ruby
 node.default['fb_apache']['sites']['*:80'] = {
@@ -69,10 +76,11 @@ Would produce:
 </VirtualHost>
 ```
 
-This can be used for anything which repeats such as `Alias`, `ServerAlias`, or `ScriptAlias`.
+This can be used for anything which repeats such as `Alias`, `ServerAlias`, or
+`ScriptAlias`.
 
-If the value is a hash, then the key is treated like another markup tag in the config and the hash is values inside that tag. For example:
-
+If the value is a hash, then the key is treated like another markup tag in the
+config and the hash is values inside that tag. For example:
 
 ```
 node.default['fb_apache']['sites']['*:80'] = {
@@ -96,13 +104,22 @@ Would produce:
 </VirtualHost>
 ```
 
-Note that you have to include the entire tag here (`Directory /var/www`, instead of just `Directory`).
+Note that you have to include the entire tag here (`Directory /var/www`,
+instead of just `Directory`).
 
 Hashes like this work for all nested tags such as `Directory` and `Location`.
 
 #### Rewrite rules
 
-One exception to this generic 1:1 mapping is rewrite rules. Because of the complicated nature of rewrite rules and because they are not structured like most of Apache VirtualHost configuration, these are special-cased in this cookbook. These can be stored in the special `_rewrites` key in the hash. Each conditional/rewrite set is an entry in the hash. The key is a human-readable name (will be used as a comment) and the value is another hash with a "conditions" array and a "rule" array. Note that you just like conditionals in apache, multiple conditionals in the same block will be ANDed together. To get OR, make an additional entry in the hash. So for example:
+One exception to this generic 1:1 mapping is rewrite rules. Because of the
+complicated nature of rewrite rules and because they are not structured like
+most of Apache VirtualHost configuration, these are special-cased in this
+cookbook. These can be stored in the special `_rewrites` key in the hash. Each
+conditional/rewrite set is an entry in the hash. The key is a human-readable
+name (will be used as a comment) and the value is another hash with a
+"conditions" array and a "rule" array. Note that you just like conditionals in
+apache, multiple conditionals in the same block will be ANDed together. To get
+OR, make an additional entry in the hash. So for example:
 
 ```
 node.default['fb_apache']['sites']['*:80'] = {
@@ -138,9 +155,9 @@ By default the key-value pairs in the hash are mapped to KEY="value" pairs in
 the file (the keys are up-cased and values are enclosed in quotes) with two
 exceptions:
 
-* If the value is an array, it is joined on strings. We preset 'options' (RHEL)
-  and 'htcacheclean_options' (Debian) to empty arrays for convenience
-* If the key is '_extra_lines`, see below.
+* If the value is an array, it is joined on strings. We preset `options` (RHEL)
+  and `htcacheclean_options` (Debian) to empty arrays for convenience
+* If the key is `_extra_lines`, see below.
 
 `node['fb_apache']['sysconfig']['_extra_lines']` is an array and every line in
 it is put at the end of the file verbatim.

--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -4,9 +4,17 @@
 # Copyright (c) 2016-present, Facebook, Inc.
 # All rights reserved.
 #
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 moddir = value_for_platform_family(
@@ -33,8 +41,8 @@ default['fb_apache'] = {
     "authz_#{auth_core_suffix}",
     'authz_groupfile',
     'authz_host',
-    'authz_user',
     'authz_owner',
+    'authz_user',
     'autoindex',
     'deflate',
     'dir',
@@ -73,6 +81,7 @@ default['fb_apache'] = {
     'cgi' => 'mod_cgi.so',
     'dav_fs' => 'mod_dav_fs.so',
     'dav' => 'mod_dav.so',
+    'dav_svn' => 'mod_dav_svn.so',
     'dbd' => 'mod_dbd.so',
     'deflate' => 'mod_deflate.so',
     'dir' => 'mod_dir.so',
@@ -94,6 +103,7 @@ default['fb_apache'] = {
     'mime_magic' => 'mod_mime_magic.so',
     'negotiation' => 'mod_negotiation.so',
     'php5' => 'libphp5.so',
+    'php7' => 'libphp7.so',
     'proxy_ajp' => 'mod_proxy_ajp.so',
     'proxy_balancer' => 'mod_proxy_balancer.so',
     'proxy_connect' => 'mod_proxy_connect.so',
@@ -105,6 +115,7 @@ default['fb_apache'] = {
     'rewrite' => 'mod_rewrite.so',
     'setenvif' => 'mod_setenvif.so',
     'speling' => 'mod_speling.so',
+    'ssl' => 'mod_ssl.so',
     'status' => 'mod_status.so',
     'substitute' => 'mod_substitute.so',
     'suexec' => 'mod_suexec.so',
@@ -116,14 +127,23 @@ default['fb_apache'] = {
     'wsgi' => 'mod_wsgi.so',
   },
   'module_packages' => {
-    'wsgi' => value_for_platform_family(
-      'rhel' => 'mod_wsgi',
+    'dav_svn' => value_for_platform_family(
+      'rhel' => 'mod_dav_svn',
+    ),
+    'ldap' => value_for_platform_family(
+      'rhel' => 'mod_ldap',
     ),
     'php5' => value_for_platform_family(
       'rhel' => 'mod_php',
     ),
+    'php7' => value_for_platform_family(
+      'rhel' => 'mod_php',
+    ),
     'ssl' => value_for_platform_family(
       'rhel' => 'mod_ssl',
+    ),
+    'wsgi' => value_for_platform_family(
+      'rhel' => 'mod_wsgi',
     ),
   },
 }

--- a/cookbooks/fb_apache/libraries/default.rb
+++ b/cookbooks/fb_apache/libraries/default.rb
@@ -4,9 +4,17 @@
 # Copyright (c) 2016-present, Facebook, Inc.
 # All rights reserved.
 #
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 module FB
@@ -14,10 +22,10 @@ module FB
     # Any exceptions to the normal hash->apache 1:1 mapping
     HANDLERS = {
       '_rewrites' => 'template_rewrite_helper',
-    }
+    }.freeze
 
     def self.indentstr(indent)
-      indent.times.map { '  ' }.join('')
+      '  ' * indent
     end
 
     # Map a hash to a apache-style syntax

--- a/cookbooks/fb_apache/metadata.rb
+++ b/cookbooks/fb_apache/metadata.rb
@@ -1,9 +1,13 @@
+# Copyright (c) 2016-present, Facebook, Inc.
 name 'fb_apache'
 maintainer 'Facebook'
 maintainer_email 'noreply@facebook.com'
-license 'BSD'
+license 'Apache-2.0'
 description 'Installs/Configures Apache'
 source_url 'https://github.com/facebook/chef-cookbooks/'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
+supports 'centos'
+supports 'debian'
+supports 'ubuntu'
 depends 'fb_helpers'

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -5,25 +5,64 @@
 # Copyright (c) 2016-present, Facebook, Inc.
 # All rights reserved.
 #
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
-confdir = value_for_platform_family(
-  'rhel' => '/etc/httpd/conf.d',
-  'debian' => '/etc/apache2/conf.d',
-)
+apache_version =
+  case node['platform_family']
+  when 'debian'
+    case node['platform']
+    when 'ubuntu'
+      node['platform_version'].to_f >= 13.10 ? '2.4' : '2.2'
+    when 'debian'
+      node['platform_version'].to_f >= 8.0 ? '2.4' : '2.2'
+    else
+      '2.4'
+    end
+  when 'rhel'
+    node['platform_version'].to_f >= 7.0 ? '2.4' : '2.2'
+  end
+
+confdir =
+  case node['platform_family']
+  when 'rhel'
+    '/etc/httpd/conf.d'
+  when 'debian'
+    case apache_version
+    when '2.2'
+      '/etc/apache2/conf.d'
+    when '2.4'
+      '/etc/apache2/conf-enabled'
+    end
+  end
 
 sitesdir = value_for_platform_family(
   'rhel' => confdir,
   'debian' => '/etc/apache2/sites-enabled',
 )
 
-moddir = value_for_platform_family(
-  'rhel' => '/etc/httpd/conf.modules.d',
-  'debian' => '/etc/apache2/modules-enabled',
-)
+moddir =
+  case node['platform_family']
+  when 'rhel'
+    '/etc/httpd/conf.modules.d'
+  when 'debian'
+    case apache_version
+    when '2.2'
+      '/etc/apache2/modules-enabled'
+    when '2.4'
+      '/etc/apache2/mods-enabled'
+    end
+  end
 
 sysconfig = value_for_platform_family(
   'rhel' => '/etc/sysconfig/httpd',
@@ -59,6 +98,14 @@ template sysconfig do
   notifies :restart, 'service[apache]'
 end
 
+[moddir, sitesdir, confdir].uniq.each do |dir|
+  directory dir do
+    owner 'root'
+    group 'root'
+    mode '0755'
+  end
+end
+
 template "#{moddir}/fb_modules.conf" do
   not_if { node.centos6? }
   owner 'root'
@@ -71,14 +118,14 @@ template "#{sitesdir}/fb_sites.conf" do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :restart, 'service[apache]'
+  notifies :reload, 'service[apache]'
 end
 
 template "#{confdir}/fb_apache.conf" do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :restart, 'service[apache]'
+  notifies :reload, 'service[apache]'
 end
 
 service 'apache' do

--- a/cookbooks/fb_apache/templates/default/apache_conf.erb
+++ b/cookbooks/fb_apache/templates/default/apache_conf.erb
@@ -1,5 +1,5 @@
 <% @conf.each do |keyword, data| %>
-<%   if data.is_a?(String) %>
+<%   if data.is_a?(String) || data.is_a?(Fixnum) %>
   <%=  keyword %> <%= data %>
 <%   elsif data.is_a?(Array) %>
 <%     data.each do |entry| %>
@@ -7,6 +7,8 @@
 <%     end %>
 <%   elsif data.is_a?(Hash) %>
 <%     FB::Apache.template_hash_handler(_buf, 1, keyword, data) %>
+<%   else %>
+<%     fail "fb_apache: bad type for value of #{keyword}: #{data.class}" %>
 <%   end %>
 <% end %>
 


### PR DESCRIPTION
There's a few fixes and features.

Tested on scale-web1 and it worked fine.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
