### PR TITLE
Client fixes

### DIFF
--- a/cookbooks/scale_chef_client/recipes/default.rb
+++ b/cookbooks/scale_chef_client/recipes/default.rb
@@ -8,7 +8,11 @@
 #
 
 # omfg I hate this so much
-cookbook_file '/var/chef/cache/chef-13.12.14-1.el7.x86_64.rpm' do
+rpmpath = File.join(
+    Chef::Config['file_cache_path'],
+    'chef-13.12.14-1.el7.x86_64.rpm',
+)
+cookbook_file rpmpath do
   owner 'root'
   group 'root'
   mode '0644'
@@ -22,7 +26,7 @@ ruby_block 'reexec chef' do
 end
 
 package 'chef' do
-  source '/var/chef/cache/chef-13.12.14-1.el7.x86_64.rpm'
+  source rpmpath
   action :upgrade
   notifies :run, 'ruby_block[reexec chef]', :immediately
 end

--- a/cookbooks/scale_chef_client/templates/default/client-prod.rb.erb
+++ b/cookbooks/scale_chef_client/templates/default/client-prod.rb.erb
@@ -6,3 +6,7 @@ cookbook_path [
 role_path '<%= node['scale_chef_client']['role_dir'] %>'
 ohai.optional_plugins ||= []
 ohai.optional_plugins += [:shard]
+follow_client_key_symlink true
+client_fork false
+no_lazy_load false
+local_key_generation true

--- a/taste-tester-plugin.rb
+++ b/taste-tester-plugin.rb
@@ -1,0 +1,9 @@
+def self.test_remote_client_rb_extra_code(_hostname)
+  <<~EOF
+
+    follow_client_key_symlink true
+    client_fork false
+    no_lazy_load false
+    local_key_generation true
+  EOF
+end

--- a/taste-tester.conf
+++ b/taste-tester.conf
@@ -13,3 +13,4 @@ use_ssl false
 use_ssh_tunnels true
 chef_zero_logging true
 user ENV['USER']
+plugin_path 'taste-tester-plugin.rb'


### PR DESCRIPTION
* use the cache path so it always exists
* clean the code up a bit
* update the config to follow symlinks so that TT'ing on a new machine
  works
* update TT to send a sane config

Signed-off-by: Phil Dibowitz <phil@ipom.com>
