### PR TITLE
update monitor config path for Datadog

### DIFF
--- a/cookbooks/scale_datadog/providers/monitor_configs.rb
+++ b/cookbooks/scale_datadog/providers/monitor_configs.rb
@@ -14,7 +14,7 @@ action :update do
   end
 
   node['scale_datadog']['monitors'].to_hash.each do |monitor, config|
-    template "/etc/datadog-agent/conf.d/#{monitor}.yaml" do
+    template "/etc/datadog-agent/conf.d/#{monitor}.d/#{monitor}.yaml" do
       source 'monitor.yaml.erb'
       owner 'dd-agent'
       group 'root'


### PR DESCRIPTION
### What does this PR do?

Per integration configs belong in conf.d/{monitor}.d/{monitor}.yaml
This moves them there.
