### PR TITLE
scale_datadog: drop chef_handler dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cookbooks/chef_handler"]
-	path = cookbooks/chef_handler
-	url = https://github.com/chef-cookbooks/chef_handler.git

--- a/cookbooks/scale_datadog/metadata.rb
+++ b/cookbooks/scale_datadog/metadata.rb
@@ -6,4 +6,3 @@ description 'Installs/Configures datadog'
 source_url 'https://github.com/socallinuxexpo/scale-chef'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
-depends 'chef_handler'

--- a/cookbooks/scale_datadog/recipes/dd-handler.rb
+++ b/cookbooks/scale_datadog/recipes/dd-handler.rb
@@ -20,20 +20,10 @@
 
 require 'uri'
 
-if Chef::Config[:why_run]
-  # chef_handler 1.1 needs us to require datadog handler's file,
-  # which makes why-run runs fail when chef-handler-datadog is not installed,
-  # so skip the recipe when in why-run mode until we can use chef_handler 1.2
-  Chef::Log.warn('Running in why-run mode, skipping dd-handler')
-  return
-end
-
 unless File.exist?('/etc/datadog_secrets')
   Chef::Log.warn('No /etc/datadog_secrets, skipping datadog setup')
   return
 end
-
-include_recipe 'chef_handler'
 
 chef_gem 'chef-handler-datadog' do # ~FC009
   action :install


### PR DESCRIPTION
chef_handler is upstream now: https://docs.chef.io/resources/chef_handler/