### PR TITLE
missing separator for aliases maps

### DIFF
--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -168,7 +168,7 @@ node.default['fb_postfix']['aliases']['listmaster'] =
   'listmaster@linuxfests.org'
 
 node.default['fb_postfix']['main.cf']['alias_maps'] <<
-  'hash:/var/lib/mailman/data/aliases'
+  ',hash:/var/lib/mailman/data/aliases'
 
 {
   'mydestination' =>


### PR DESCRIPTION
we append /var/lib/mailman/data/aliases to aliasmaps which is a string with an existing value. postfix expects two values to be separated by a coma