### PR TITLE
use correct port when generating sasl_passwd

### DIFF
--- a/cookbooks/fb_init/recipes/site_settings.rb
+++ b/cookbooks/fb_init/recipes/site_settings.rb
@@ -49,7 +49,7 @@ elsif File.exist?('/etc/sasl_passwd')
     node.default['fb_postfix']['main.cf'][k] = v
   end
 
-  node.default['fb_postfix']['sasl_passwd']['smtp.mailgun.org:2525'] =
+  node.default['fb_postfix']['sasl_passwd']['smtp.mailgun.org'] =
     File.read('/etc/sasl_passwd').chomp.split(' ')[1]
 else
   fail 'fb_init: /etc/sasl_passwd is missing, cannot setup mailgun'


### PR DESCRIPTION
we should probably have this re-use the existing attributes from sasl_passwd. or just use the existing /etc/sasl_passwd instead of regenerating it like this... but on to making mail work again.