### PR TITLE
listen on public interface for mail

### DIFF
--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -170,6 +170,8 @@ node.default['fb_postfix']['aliases']['listmaster'] =
 node.default['fb_postfix']['main.cf']['alias_maps'] <<
   ',hash:/var/lib/mailman/data/aliases'
 
+node.default['fb_postfix']['main.cf']['inet_interfaces'] = "all"
+
 {
   'mydestination' =>
     'lists.linuxfests.org, $myhostname, localhost.$mydomain, localhost',


### PR DESCRIPTION
fb_postfix only listens on local host by default. not helpful for public mail servers.