### PR TITLE
Fix certbot

### DIFF
--- a/cookbooks/scale_apache/recipes/certs.rb
+++ b/cookbooks/scale_apache/recipes/certs.rb
@@ -1,4 +1,4 @@
-package 'certbot' do
+package ['certbot', 'python-acme'] do
   action :upgrade
 end
 


### PR DESCRIPTION
New version no longer explicilty declares a dep on python-acme.