### PR TITLE
Move mailman and phplist to supported packages

### DIFF
--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -49,6 +49,12 @@ common_config.merge({
   node.default['fb_apache']['sites']['_default_:443'][key] = val
 end
 
+package 'downgrade mailman' do
+  only_if { node['packages']['mailman']['release'].match('fc25') }
+  package_name 'mailman'
+  action :remove
+end
+
 pkgs = %w{
   php
   php-gd
@@ -57,7 +63,9 @@ pkgs = %w{
   php-xml
   python-dns
   python2-boto
+  mailman
 }
+
 package pkgs do
   action :upgrade
   notifies :restart, 'service[apache]'
@@ -68,20 +76,6 @@ cookbook_file '/var/www/html/index.html' do
   owner 'root'
   group 'root'
   mode '0644'
-end
-
-remote_file "#{Chef::Config['file_cache_path']}/mailman-2.1.21-1.fc25.x86_64.rpm" do
-  not_if { File.exists?('/usr/lib/mailman/bin/mailmanctl') }
-  source 'https://s3.amazonaws.com/scale-packages/mailman-2.1.21-1.fc25.x86_64.rpm'
-  owner 'root'
-  group 'root'
-  mode '0644'
-  action :create
-end
-
-package 'mailman' do
-  not_if { File.exists?('/usr/lib/mailman/bin/mailmanctl') }
-  source "#{Chef::Config['file_cache_path']}/mailman-2.1.21-1.fc25.x86_64.rpm"
 end
 
 ## RESTORE BACKUPS

--- a/cookbooks/scale_phplist/recipes/default.rb
+++ b/cookbooks/scale_phplist/recipes/default.rb
@@ -7,6 +7,7 @@ pkgs = %w{
   php
   php-mysql
   php-imap
+  phplist
 }
 
 package pkgs do
@@ -14,40 +15,29 @@ package pkgs do
   notifies :restart, 'service[apache]'
 end
 
-remote_file 'fetch phplist tarball' do
-  not_if do
-    File.directory?("/usr/local/phplist-#{node['scale_phplist']['version']}")
-  end
-  source lazy {
-    "https://s3.amazonaws.com/scale-packages/phplist-#{node['scale_phplist']['version']}.tgz"
-  }
-  path lazy { 
-    "#{Chef::Config['file_cache_path']}/phplist-#{node['scale_phplist']['version']}.tgz" 
-  }
-  owner 'root'
-  group 'root'
-  mode '0644'
-  action :create
-end
-
-execute 'extract phplist tarball' do
-  command lazy {
-    "tar xf #{Chef::Config['file_cache_path']}/phplist-#{node['scale_phplist']['version']}.tgz -C /usr/local/ --owner=root --group=apache"
-  }
-  creates lazy { "/usr/local/phplist-#{node['scale_phplist']['version']}" }
-end
-
-template 'config.php' do
-  path lazy { 
-    "/usr/local/phplist-#{node['scale_phplist']['version']}/public_html/lists/config/config.php" 
-  }
+template '/usr/share/phplist/public_html/lists/config/config.php' do
   owner 'root'
   group 'apache'
   mode '0640'
 end
 
+# migrate from old tarball install
 link '/var/www/html/lists' do
-  to lazy {
-    "/usr/local/phplist-#{node['scale_phplist']['version']}/public_html/lists" 
+  only_if { File.symlink?('/var/www/html/lists') }
+  action :delete
+end
+
+execute 'migrate lists' do
+  only_if do
+    File.directory?(
+      "/usr/local/phplist-#{node['scale_phplist']['version']}/public_html/lists"
+    ) &&
+    ! File.directory?('/var/www/html/lists')
+  end
+  command lazy {
+    old =
+      "/usr/local/phplist-#{node['scale_phplist']['version']}/public_html/list"
+    new = '/var/www/html/lists'
+    "mv #{old} #{new}"
   }
 end

--- a/cookbooks/scale_yum/recipes/default.rb
+++ b/cookbooks/scale_yum/recipes/default.rb
@@ -16,3 +16,18 @@ package 'epel-release' do
   source "#{Chef::Config['file_cache_path']}/#{epel_pkg}"
 end
 
+lux_pkg = 'lux-release-7-1.noarch.rpm'
+
+remote_file "#{Chef::Config['file_cache_path']}/#{lux_pkg}" do
+  not_if { File.exists?('/etc/yum.repos.d/lux.repo') }
+  source "http://repo.iotti.biz/CentOS/7/noarch/#{lux_pkg}"
+  owner 'root'
+  group 'root'
+  mode '0644'
+  action :create
+end
+
+package 'lux-release' do
+  not_if { File.exists?('/etc/yum.repos.d/lux.repo') }
+  source "#{Chef::Config['file_cache_path']}/#{lux_pkg}"
+end


### PR DESCRIPTION
This is not yet tested, do not merge.

* We're on some FC version of mailman for reasons no one can recall,
so downgrading to the C7 supported RPM, so it will be
auto-kept-up-to-date
* Moving to the Lux repo for phplist for the same reason