### PR TITLE
fb_init: remove cockpit on c8s and later

### DIFF
--- a/cookbooks/fb_init/recipes/site_settings.rb
+++ b/cookbooks/fb_init/recipes/site_settings.rb
@@ -105,6 +105,16 @@ to_remove = %w{
   rpcbind
   abrt
 }
+
+# c8s and later preinstall cockpit, do not want
+unless node.centos7?
+  to_remove += %w{
+    cockpit-system
+    cockpit-ws
+    cockpit-bridge
+  }
+end
+
 package to_remove do
   action :remove
 end


### PR DESCRIPTION
This is preinstalled in cloud images but we don't need it