### PR TITLE
scale_apache: python-acme is only needed on C7

### DIFF
--- a/cookbooks/scale_apache/recipes/certs.rb
+++ b/cookbooks/scale_apache/recipes/certs.rb
@@ -1,4 +1,9 @@
-package ['certbot', 'python-acme'] do
+pkgs = %w{certbot}
+if node.centos7?
+  pkgs << 'python-acme'
+end
+
+package pkgs do
   action :upgrade
 end
 


### PR DESCRIPTION
This isn't a dependency on C8