### PR TITLE
Update chef_bootstrap for modern times

### DIFF
--- a/scripts/chef_bootstrap.sh
+++ b/scripts/chef_bootstrap.sh
@@ -11,17 +11,34 @@ OUTPUTS="/var/log/chef"
 
 bootstrap() {
   [ -x /bin/wget ] || yum install -y wget
-  [ ! -d /opt/cinc ] && \
+  if [ ! -d /opt/cinc ]; then
+    mkdir -p /etc/chef $CHEFDIR $REPODIR $OUTPUTS
     wget -qO- 'https://omnitruck.cinc.sh/install.sh' | bash
-  mkdir -p /etc/chef $CHEFDIR $REPODIR $OUTPUTS
+  fi
   ln -sf /etc/chef /etc/cinc
   cat > $CHEF_PROD_CONFIG <<EOF
 cookbook_path [
   '/var/chef/repo/cookbooks',
 ]
 role_path '/var/chef/repo/roles'
+ohai.optional_plugins ||= []
+ohai.optional_plugins += [:shard]
+follow_client_key_symlink true
+client_fork false
+no_lazy_load false
+local_key_generation true
 local_mode true
+json_attribs '$RUNLIST_FILE'
 EOF
+
+  for key in client-prod validation; do
+      file="/etc/chef/$key.pem"
+      if ! [ -e "$file" ]; then
+          # Key isn't used in local mode, so no specific options
+          # are really necessary
+          openssl genrsa -out "$file"
+      fi
+  done
 
   ln -sf /etc/chef/client-prod.rb /etc/chef/client.rb
   ln -sf /etc/chef/client-prod.pem /etc/chef/client.pem
@@ -33,5 +50,16 @@ EOF
 EOF
   [ -x /bin/git ] || yum install -y git
 }
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Ray, when somebody asks you if you're a god, you say YES!"
+    echo "(run this as root)"
+    exit 1
+fi
+
+if ! [ -d "$REPODIR" ]; then
+    echo "Please make /var/chef/repo a git clone of the scale-chef repo"
+    exit 1
+fi
 
 bootstrap


### PR DESCRIPTION
Update chef_bootstrap for modern times

Summary:

This should work better.

Test Plan:

bash -n passes

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/socallinuxexpo/scale-chef/pull/247).
* __->__ #247
