### PR TITLE
sync fb_hostconf with upstream

### DIFF
--- a/cookbooks/fb_hostconf/metadata.rb
+++ b/cookbooks/fb_hostconf/metadata.rb
@@ -5,7 +5,6 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Configures /etc/host.conf'
 source_url 'https://github.com/facebook/chef-cookbooks/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.1'
 supports 'centos'
 supports 'debian'


### PR DESCRIPTION
sync fb_hostconf with upstream

Summary:

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/socallinuxexpo/scale-chef/pull/255).
* __->__ #255
