### PR TITLE
sync fb_modprobe with upstream

### DIFF
--- a/cookbooks/fb_modprobe/libraries/default.rb
+++ b/cookbooks/fb_modprobe/libraries/default.rb
@@ -29,10 +29,21 @@ module FB
 
     def self.module_refcnt(loaded_mod)
       loaded_mod.tr!('-', '_')
-      version_file = "/sys/module/#{loaded_mod}/refcnt"
+      refcnt_file = "/sys/module/#{loaded_mod}/refcnt"
 
-      if File.exist?(version_file)
-        return IO.read(version_file).strip
+      if File.exist?(refcnt_file)
+        return IO.read(refcnt_file).strip
+      end
+
+      nil
+    end
+
+    def self.module_opt(loaded_mod, param)
+      loaded_mod.tr!('-', '_')
+      param_file = "/sys/module/#{loaded_mod}/parameters/#{param}"
+
+      if File.exist?(param_file)
+        return IO.read(param_file).strip
       end
 
       nil

--- a/cookbooks/fb_modprobe/metadata.rb
+++ b/cookbooks/fb_modprobe/metadata.rb
@@ -5,7 +5,6 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/Configures modprobe'
 source_url 'https://github.com/facebook/chef-cookbooks/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.1'
 supports 'centos'
 depends 'fb_helpers'

--- a/cookbooks/fb_modprobe/resources/module.rb
+++ b/cookbooks/fb_modprobe/resources/module.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 default_action :load
 
 property :module_name, :kind_of => String, :name_property => true
@@ -21,10 +22,6 @@ property :verbose, :kind_of => [TrueClass, FalseClass], :default => false
 property :timeout, :kind_of => Integer, :default => 300
 property :fallback, :kind_of => [TrueClass, FalseClass], :default => false
 property :module_params, :kind_of => [String, Array], :required => false
-
-def whyrun_supported?
-  true
-end
 
 action_class do
   def modprobe_module(new_resource, unload)
@@ -41,21 +38,21 @@ action_class do
     # Correctly handle built-in modules. If no parameters were supplied, we
     # just return true. If the caller supplied parameters, we fail the Chef run
     # and ask them to fix their cookbook, since we can't apply them.
-    if ::File.exist?("/sys/module/#{module_name}")
-      unless ::File.exist?("/sys/module/#{module_name}/initstate")
-        ::Chef::Log.warn(
-          "fb_modprobe called on built-in module '#{module_name}'",
-        )
-        unless params.empty?
-          fail <<-FAIL
+    if ::File.exist?("/sys/module/#{module_name}") &&
+        !::File.exist?("/sys/module/#{module_name}/initstate")
+      ::Chef::Log.warn(
+        "fb_modprobe called on built-in module '#{module_name}'",
+      )
+      unless params.empty?
+        fail <<-FAIL
           Cannot set parameters for built-in module '#{module_name}'!
           Parameters for built-in modules must be passed on the kernel cmdline.
           Prefix the parameter with the module name and a dot.
           Examples: "ipv6.autoconf=1", "mlx4_en.udp_rss=1"
-          FAIL
-        end
-        return True
+        FAIL
       end
+
+      return true
     end
 
     command = ['/sbin/modprobe'] + flags + [module_name] + params
@@ -85,9 +82,9 @@ action :load do
 end
 
 action :unload do
-  if !FB::Modprobe.module_loaded?(new_resource.module_name)
-    Chef::Log.debug("#{new_resource}: Module already unloaded")
-  else
+  if FB::Modprobe.module_loaded?(new_resource.module_name)
     modprobe_module(new_resource, true)
+  else
+    Chef::Log.debug("#{new_resource}: Module already unloaded")
   end
 end

--- a/cookbooks/fb_modprobe/templates/default/modules-load.conf.erb
+++ b/cookbooks/fb_modprobe/templates/default/modules-load.conf.erb
@@ -1,6 +1,6 @@
 # This file is maintained by Chef. Do not edit, all changes will be
 # overwritten. See fb_modprobe/README.md
 
-<% node['fb_modprobe']['modules_to_load_on_boot'].each do |kmod| %>
+<% node['fb_modprobe']['modules_to_load_on_boot'].uniq.each do |kmod| %>
 <%=  kmod %>
 <% end %>


### PR DESCRIPTION
sync fb_modprobe with upstream

Summary:

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/socallinuxexpo/scale-chef/pull/260).
* __->__ #260
