### PR TITLE
sync fb_nsswitch with upstream

### DIFF
--- a/cookbooks/fb_nsswitch/metadata.rb
+++ b/cookbooks/fb_nsswitch/metadata.rb
@@ -5,7 +5,6 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Installs/Configures /etc/nsswitch.conf'
 source_url 'https://github.com/facebook/chef-cookbooks/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.1'
 supports 'centos'
 supports 'debian'


### PR DESCRIPTION
sync fb_nsswitch with upstream

Summary:

Test Plan:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/socallinuxexpo/scale-chef/pull/262).
* __->__ #262
