### PR TITLE
Add MaxConnectionsPerChild to prevent memory leak related crashes

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -45,6 +45,8 @@ node.default['fb_apache']['sites']['*:80'] = common_config.merge({
     'https://www.socallinuxexpo.org/',
 })
 
+node.default['fb_apache']['extra_configs']['MaxConnectionsPerChild'] = 15
+
 base_config = common_config.merge({
   'Alias' => [
     '/past /home/webroot/past',


### PR DESCRIPTION
Add MaxConnectionsPerChild to prevent memory leak related crashes

Summary:

Starting at 15, because why not

Test Plan:

Implemented manually on www, worked.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/socallinuxexpo/scale-chef/pull/268).
* __->__ #268
