### PR TITLE
[mailman] update backups to use aws-cli

### DIFF
--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -58,6 +58,7 @@ pkgs = %w{
 
 if node.centos7?
   pkgs += %w{
+    awscli
     php-mysql
     python-dns
     python2-boto

--- a/cookbooks/scale_mailman/templates/default/backup-mailman.sh.erb
+++ b/cookbooks/scale_mailman/templates/default/backup-mailman.sh.erb
@@ -5,22 +5,22 @@ TMPFILE=`mktemp -d`
 DATE=`date +%Y/%m/%d`
 TIME=`date +%H-%M-%S`
 
-S3KEY="<%= node['scale_mailman']['s3_aws_access_key_id'] %>"
-S3SECRET="<%= node['scale_mailman']['s3_aws_secret_access_key'] %>"
+export AWS_ACCESS_KEY_ID="<%= node['scale_mailman']['s3_aws_access_key_id'] %>"
+export AWS_SECRET_ACCESS_KEY="<%= node['scale_mailman']['s3_aws_secret_access_key'] %>"
 
 echo "Starting backup...."
-tar cfz $TMPFILE/mailman-archives_${HOSTNAME}_${TIME}.tar.gz -C /var/lib/mailman/ archives
-tar cfz $TMPFILE/mailman-configs_${HOSTNAME}_${TIME}.tar.gz -C /var/lib/mailman/ {data,lists}
+tar cfz ${TMPFILE}/mailman-archives_${HOSTNAME}_${TIME}.tar.gz -C /var/lib/mailman/ archives
+tar cfz ${TMPFILE}/mailman-configs_${HOSTNAME}_${TIME}.tar.gz -C /var/lib/mailman/ {data,lists}
 
 echo "Uploading backup...."
 
 for type in archives configs
 do
-  s3put --region=us-east-1 --access_key ${S3KEY} --secret_key ${S3SECRET} --bucket ${BUCKET} --prefix ${TMPFILE} --key_prefix ${type}/$DATE/ ${TMPFILE}/mailman-${type}_${HOSTNAME}_${TIME}.tar.gz
+  aws s3 cp --region us-east-1 ${TMPFILE}/mailman-${type}_${HOSTNAME}_${TIME}.tar.gz s3://scale-mailman-backups/archives/${DATE}/mailman-${type}_${HOSTNAME}_${TIME}.tar.gz
 
   if [ $? -eq 0 ]; then
     echo "Upload of mailman-${type} complete";
-    rm "${TMPFILE}/mailman-archives_${HOSTNAME}_${TIME}.tar.gz"
+    rm "${TMPFILE}/mailman-${type}_${HOSTNAME}_${TIME}.tar.gz"
   fi
 done
 


### PR DESCRIPTION
### What does this PR do?

update mailman backups to use aws-cli instead of s3put

### Motivation

backups broke when we moved to a newer distro as boto3 doesn't include the same cli commands as boto2