### PR TITLE
[apache] set MaxRequestWorkers to 30

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -44,6 +44,7 @@ node.default['fb_apache']['sites']['*:80'] = common_config.merge({
 })
 
 node.default['fb_apache']['extra_configs']['MaxConnectionsPerChild'] = 5
+node.default['fb_apache']['extra_configs']['MaxRequestWorkers'] = 30
 
 base_config = common_config.merge({
   'Alias' => [


### PR DESCRIPTION
### What does this PR do?

set MaxRequestWorkers to 30 on apache, as we're seeing more workers than memory available on the system.
