### PR TITLE
update to epel-release-7-14.noarch.rpm

### DIFF
--- a/cookbooks/scale_yum/recipes/default.rb
+++ b/cookbooks/scale_yum/recipes/default.rb
@@ -1,7 +1,7 @@
 # vim:shiftwidth=2:expandtab
 
 if node.centos7?
-  epel_pkg = 'epel-release-7-12.noarch.rpm'
+  epel_pkg = 'epel-release-7-14.noarch.rpm'
 
   remote_file "#{Chef::Config['file_cache_path']}/#{epel_pkg}" do
     not_if { File.exists?('/etc/yum.repos.d/epel.repo') }


### PR DESCRIPTION
update to epel-release-7-12 is no longer available move to update to epel-release-7-14.