### PR TITLE
migrate scale web role to centos8

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -234,29 +234,21 @@ node.default['fb_apache']['sites']['_default_:443']['_rewrites'] = rewrites
   node.default['fb_apache']['sites']['_default_:443'][key] = val
 end
 
+pkgs = %w{
+  git
+  php
+  php-gd
+  php-pdo
+  php-xml
+  php-mbstring
+}
 if node.centos7?
-  pkgs = %w{
-    git
-    php
-    php-gd
-    php-mysql
-    php-pdo
-    php-xml
-    php-mbstring
-    python2-boto
-  }
-elsif node.centos8?
-  pkgs = %w{
-    git
-    php
-    php-gd
-    php-json
-    php-mysqlnd
-    php-pdo
-    php-xml
-    php-mbstring
-    python3-boto3
-  } 
+  pkgs << 'python2-boto'
+  pkgs << 'php-mysql'
+else
+  pkgs << 'python3-boto3'
+  pkgs << 'php-mysqlnd'
+  pkgs << 'php-json'
 end
 
 if node.centos8?

--- a/cookbooks/scale_drupal/recipes/default.rb
+++ b/cookbooks/scale_drupal/recipes/default.rb
@@ -8,6 +8,12 @@
 #
 
 package 'drush' do
+  only_if { node.centos7? }
+  action :upgrade
+end
+
+package 'awscli' do
+  not_if { node.centos7? }
   action :upgrade
 end
 
@@ -68,18 +74,28 @@ template '/home/drupal/scale-drupal/httpdocs/sites/default/settings.php' do
   mode '0640'
 end
 
+# new stuff is py3
+restore_source = 'restore-drupal-static3.py.erb'
+backup_source = 'backup-drupal-static3.sh.erb'
+
+# support for older OSes until we finish upgrades/migrations
+if node.centos6? || node.centos7?
+  restore_source = 'restore-drupal-static.py.erb'
+  backup_source = 'backup-drupal-static.sh.erb'
+end
+
 template '/usr/local/bin/backup-drupal-static.sh' do
   owner 'root'
   group 'root'
   mode '0755'
-  source 'backup-drupal-static.sh.erb'
+  source backup_source
 end
 
 template '/usr/local/bin/restore-drupal-static.py' do
   owner 'root'
   group 'root'
   mode '0755'
-  source 'restore-drupal-static.py.erb'
+  source restore_source
 end
 
 execute '/usr/local/bin/restore-drupal-static.py' do

--- a/cookbooks/scale_drupal/templates/default/backup-drupal-static3.sh.erb
+++ b/cookbooks/scale_drupal/templates/default/backup-drupal-static3.sh.erb
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+BUCKET="scale-drupal-backups"
+TMPFILE=`mktemp -d`
+DATE=`date +%Y/%m/%d`
+TIME=`date +%H-%M-%S`
+TARGET="drupal-static_${HOSTNAME}_${TIME}.tar.gz"
+
+export AWS_ACCESS_KEY_ID="<%= node['scale_apache']['s3_aws_access_key_id'] %>"
+export AWS_SECRET_ACCESS_KEY="<%= node['scale_apache']['s3_aws_secret_access_key'] %>"
+
+echo "Starting backup...."
+tar cfz $TMPFILE/${TARGET} -C /home/drupal/scale-drupal/httpdocs/sites/default/ files
+
+echo "Uploading backup...."
+aws s3 cp --region us-east-1 ${TMPFILE}/${TARGET} s3://${BUCKET}/${TARGET}
+
+if [ $? -eq 0 ]; then
+  rm "${TMPFILE}/${TARGET}"
+  rmdir "${TMPFILE}"
+fi

--- a/cookbooks/scale_drupal/templates/default/restore-drupal-static3.py.erb
+++ b/cookbooks/scale_drupal/templates/default/restore-drupal-static3.py.erb
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+import tempfile
+import tarfile
+import boto3
+import botocore
+
+#TODO: use instance profile instead of static keys
+access_key = "<%= node['scale_apache']['s3_aws_access_key_id'] %>"
+secret_key = "<%= node['scale_apache']['s3_aws_secret_access_key'] %>"
+
+backup_bucket = 'scale-drupal-backups'
+tmp_path = tempfile.mkdtemp()
+
+conn = boto3.client('s3', aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+
+# Find most recent backup in S3
+backup_file_name = conn.list_objects(Bucket=backup_bucket)['Contents'][-1]["Key"]
+
+local_file = tmp_path + "/" + backup_file_name.split('/').pop()
+
+#Download to tmp file
+with open(local_file, 'wb') as data:
+    conn.download_fileobj(backup_bucket, backup_file_name, data)
+
+tarfile.open(local_file).extractall(path="/home/drupal/scale-drupal/httpdocs/sites/default")


### PR DESCRIPTION
### What does this PR do?

update apache and drupal cookbooks for centos8

### Motivation

Newer is always better?

### Testing Guidelines

spin up a centos8 vm or vagrant, run it with role[web]

### Additional Notes

- Drush's official docs suggest we should be installing via composer or in our drupal code base rather than via rpm. I've skipped it for now.

- Centos8 seems to default to using php-fpm instead of mod_php.  Seems to work fine, but seemed like something to call out.


