### PR TITLE
raise MaxRequestWorkers to be a multiple of ThreadsPerChild

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -44,7 +44,7 @@ node.default['fb_apache']['sites']['*:80'] = common_config.merge({
 })
 
 node.default['fb_apache']['extra_configs']['MaxConnectionsPerChild'] = 5
-node.default['fb_apache']['extra_configs']['MaxRequestWorkers'] = 30
+node.default['fb_apache']['extra_configs']['MaxRequestWorkers'] = 50
 
 base_config = common_config.merge({
   'Alias' => [


### PR DESCRIPTION


### What does this PR do?

raise MaxRequestWorkers to be a multiple of ThreadsPerChild

