### PR TITLE
Always install atop

### DIFF
--- a/cookbooks/fb_init/recipes/site_settings.rb
+++ b/cookbooks/fb_init/recipes/site_settings.rb
@@ -57,7 +57,7 @@ end
 
 node.default['fb_postfix']['main.cf']['mydomain'] = 'localhost'
 
-package %w{postfix-perl-scripts cyrus-sasl-plain cyrus-sasl-md5} do
+package %w{postfix-perl-scripts cyrus-sasl-plain cyrus-sasl-md5 atop} do
   action :upgrade
 end
 


### PR DESCRIPTION
Always install atop

Summary:

That way we can debug stuff.

Closes #294

Test Plan:

None

Signed-off-by: Phil Dibowitz <phil@ipom.com>
