### PR TITLE
Fix apache config for server-status

### DIFF
--- a/cookbooks/scale_apache/recipes/simple.rb
+++ b/cookbooks/scale_apache/recipes/simple.rb
@@ -33,9 +33,7 @@ vhost_config = {
   },
   'Location /server-status' => {
     'SetHandler' => 'server-status',
-    'Order' => 'Deny,Allow',
-    'Deny' => 'from all',
-    'Allow' => 'from localhost',
+    'Require' => 'local',
   },
   'LogLevel' => 'warn',
 }


### PR DESCRIPTION
Requesting it from localhost works now (see below).

What I don't understand is that the logs (see #295) imply it was pulling
from https://lists.linuxfests.org, which wouldn't work and isn't
necessary, but since I fixed loopback pulling, it is no longer
error'ing. Shrug.

Closes #295

```
--2023-10-12 02:10:25--  http://localhost/server-status?auto
Resolving localhost (localhost)... ::1, 127.0.0.1
Connecting to localhost (localhost)|::1|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://lists.linuxfests.org/server-status?auto [following]
--2023-10-12 02:10:25--  https://lists.linuxfests.org/server-status?auto
Resolving lists.linuxfests.org (lists.linuxfests.org)... 2600:1f18:1a34:e402:47bc:6241:8740:7235, 52.73.170.245
Connecting to lists.linuxfests.org (lists.linuxfests.org)|2600:1f18:1a34:e402:47bc:6241:8740:7235|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1630 (1.6K) [text/plain]
Saving to: ‘server-status?auto’

server-status?auto                                                              100%[======================================================================================================================================================================================================>]   1.59K  --.-KB/s    in 0s

2023-10-12 02:10:26 (54.7 MB/s) - ‘server-status?auto’ saved [1630/1630]
```

