### PR TITLE
Restart apache slightly less often

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -13,7 +13,8 @@ include_recipe 'fb_apache'
 apache_debug_log = '/var/log/apache_status.log'
 if node['hostname'] == 'scale-web2'
   cron 'ugly restarts' do
-    minute '*/30'
+    # once an hour
+    minute '02'
     command "date >> #{apache_debug_log}; " +
       "ps auxwww | grep http >> #{apache_debug_log}; " +
       '/usr/bin/systemctl restart httpd'


### PR DESCRIPTION
Part of https://github.com/socallinuxexpo/scale-chef/pull/293 was
supposed to drop restarts to hourly, but a rebase dropped that because
those lines were changed by Ilan to fix a bug I had introduced.

This drops us down to hourly. While we may run into issues, if we do
at least now we have logging, and at worst will be down for less than an
hour.

Signed-off-by: Phil Dibowitz <phil@ipom.com>

