### PR TITLE
Restart apache more often

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -14,9 +14,10 @@ apache_debug_log = '/var/log/apache_status.log'
 if node['hostname'] == 'scale-web2'
   node.default['fb_cron']['jobs']['ugly_restarts'] = {
     # 2x a day
-    'time' => '02 11,23 * * *',
+    'time' => '02 */2 * * *',
     'command' => "date >> #{apache_debug_log}; " +
-      "ps auxwww | grep http >> #{apache_debug_log}; " +
+      'ps -eL -o user,pid,lwp,nlwp,%cpu,%mem,vsz,rss,tty,stat,start,time,cmd ' +
+      "| grep ^apache >> #{apache_debug_log}; " +
       '/usr/bin/systemctl restart httpd',
   }
 end


### PR DESCRIPTION
Restart apache more often

Summary:

It seemed like the site was getting better with all the tunings, but it
still crashes sometimes. Put restarts back at every 2 hours.

Also, DD has process info, so keeping that locally doesn't add much,
but thread snapshots might prove useful, so adding that.

Test Plan:
