### PR TITLE
Remove /safety redirect, drupal will serve that directly

### DIFF
--- a/cookbooks/scale_apache/recipes/default.rb
+++ b/cookbooks/scale_apache/recipes/default.rb
@@ -203,12 +203,6 @@ rewrites = {
       '%{REQUEST_URI} ^/scale15x$',
     ],
   },
-  'safety' => {
-    'rule' => '^/safety https://www.socallinuxexpo.org/scale/15x/anti-harassment-policy [L,R,NE]',
-    'conditions' => [
-      '%{REQUEST_URI} ^/safety$',
-    ],
-  },
   'scale 14x' => {
     'rule' => '^/(.*) https://www.socallinuxexpo.org/scale/14x [L,R,NE]',
     'conditions' => [


### PR DESCRIPTION
Remove /safety redirect, drupal will serve that directly

See https://github.com/socallinuxexpo/scale-drupal/issues/124
