### PR TITLE
[centos9] Codify all the apache modules

### DIFF
--- a/cookbooks/scale_apache/recipes/common.rb
+++ b/cookbooks/scale_apache/recipes/common.rb
@@ -7,6 +7,97 @@
 # All rights reserved - Do Not Redistribute
 #
 
+node.default['fb_apache']['modules'] += [
+  # everything in 00-base.conf (except what's in fb_apache)
+  'access_compat',
+  'actions',
+  'alias',
+  'allowmethods',
+  'authn_anon',
+  'authn_dbd',
+  'authn_dbm',
+  'authn_socache',
+  'authz_dbd',
+  'authz_dbm',
+  'brotli',
+  'cache',
+  'cache_disk',
+  'cache_socache',
+  'data',
+  'dbd',
+  'dumpio',
+  'echo',
+  'expires',
+  'ext_filter',
+  'filter',
+  'include',
+  'info',
+  'macro',
+  'mime_magic',
+  'remoteip',
+  'reqtimeout',
+  'request',
+  'rewrite',
+  'slotmem_plain',
+  'slotmem_shm',
+  'socache_dbm',
+  'socache_memcache',
+  'socache_shmcb',
+  'status',
+  'substitute',
+  'suexec',
+  'unique_id',
+  'unixd',
+  'userdir',
+  'version',
+  'vhost_alias',
+  'watchdog',
+  # and 00-ssl.conf
+  'ssl',
+  # 00-systemd.conf
+  'systemd',
+  # 10-h2.conf
+  'http2',
+]
+unless node.centos9?
+  # 15-php.conf
+   node.default['fb_apache']['modules'] << 'php7'
+end
+
+{
+  'access_compat' => 'mod_access_compat.so',
+  'allowmethods' => 'mod_allowmethods.so',
+  'authn_socache' => 'mod_authn_socache.so',
+  'authz_dbd' => 'mod_authz_dbd.so',
+  'authz_dbm' => 'mod_authz_dbm.so',
+  'brotli' => 'mod_brotli.so',
+  'cache' => 'mod_cache.so',
+  'cache_disk' => 'mod_cache_disk.so',
+  'cache_socache' => 'mod_cache_socache.so',
+  'data' => 'mod_data.so',
+  'dumpio' => 'mod_dumpio.so',
+  'echo' => 'mod_echo.so',
+  'macro' => 'mod_macro.so',
+  'remoteip' => 'mod_remoteip.so',
+  'request' => 'mod_request.so',
+  'slotmem_plain' => 'mod_slotmem_plain.so',
+  'slotmem_shm' => 'mod_slotmem_shm.so',
+  'socache_dbm' => 'mod_socache_dbm.so',
+  'socache_memcache' => 'mod_socache_memcache.so',
+  'socache_shmcb' => 'mod_socache_shmcb.so',
+  'watchdog' => 'mod_watchdog.so',
+  # 00-ssl.conf
+  'ssl' => 'mod_ssl.so',
+  # 00-systemd.conf
+  'systemd' => 'mod_systemd.so',
+  # 10-h2.conf
+  'http2' => 'mod_http2.so',
+  # 15-php.conf
+  'php7' => 'libphp7.so',
+}.each do |k, v|
+  node.default['fb_apache']['modules_mapping'][k] = v
+end
+
 directory '/etc/httpd' do
   owner 'root'
   group 'root'


### PR DESCRIPTION
Required for updating fb_apache which is required for CentOS9