### PR TITLE
Add workarounds for awscli2 on CentOS 10

### DIFF
--- a/cookbooks/scale_drupal/recipes/default.rb
+++ b/cookbooks/scale_drupal/recipes/default.rb
@@ -17,6 +17,27 @@ package 'awscli' do
   action :upgrade
 end
 
+# CentOS 10 doesn't yet have awscli2 and its dep python3-colorama
+# due to https://issues.redhat.com/browse/RHEL-64923 which is simply
+# a test failure, so we install the versions downloaded from Koji for now
+base_url = 'https://kojihub.stream.centos.org/kojifiles/vol/koji02/packages'
+colorama = "#{base_url}/python-colorama/0.4.6/13.el10/noarch" +
+  '/python3-colorama-0.4.6-13.el10.noarch.rpm'
+awscli2 = "#{base_url}/awscli2/2.17.18/4.el10/noarch" +
+  '/awscli2-2.17.18-4.el10.noarch.rpm'
+
+[colorama, awscli2].each do |url|
+  fname = File.basename(url)
+  src = "#{Chef::Config['file_cache_path']}/#{fname}"
+  remote_file src do
+    source url
+  end
+
+  package fname do
+    source src
+  end
+end
+
 cookbook_file '/usr/local/bin/deploy_site' do
   source 'deploy_site'
   owner 'root'

--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -10,13 +10,6 @@ node.default['fb_iptables']['filter']['INPUT']['rules']['allow_smtp'] = {
 node.default['fb_apache']['modules'] << 'cgi'
 node.default['fb_apache']['modules_mapping']['cgi'] = "mod_cgi.so"
 
-# On CentOS9 the EPEL9 repo depends on the CRB repo
-execute 'enable crb' do
-  only_if { node.centos9? }
-  not_if "dnf repolist | grep crb"
-  command "dnf config-manager --set-enabled crb"
-end
-
 node.default['scale_apache']['ssl_hostname'] = 'lists.socallinuxexpo.org'
 
 include_recipe 'scale_apache::simple'

--- a/cookbooks/scale_yum/recipes/default.rb
+++ b/cookbooks/scale_yum/recipes/default.rb
@@ -17,6 +17,13 @@ if node.centos7?
     source "#{Chef::Config['file_cache_path']}/#{epel_pkg}"
   end
 else
+  # On CentOS9+ the EPEL repo depends on the CRB repo
+  execute 'enable crb' do
+    only_if { node.centos_min_version?(9) }
+    not_if "dnf repolist | grep crb"
+    command "dnf config-manager --set-enabled crb"
+  end
+
   package 'epel-release' do
     action :upgrade
   end


### PR DESCRIPTION
* move CRB from mailman to yum
* add workarounds for awscli2 and colorama which aren't upstream yet

Taste-tested on web and lists
