### PR TITLE
reg-centos10: final tweaks

### DIFF
--- a/cookbooks/fb_iptables/recipes/packages.rb
+++ b/cookbooks/fb_iptables/recipes/packages.rb
@@ -19,7 +19,11 @@
 # limitations under the License.
 #
 
-packages = ['iptables']
+if node.centos_min_version?(9)
+  packages = ['iptables-nft']
+else
+  packages = ['iptables']
+end
 
 if node.ubuntu?
   packages << 'iptables-persistent'


### PR DESCRIPTION
* A fix to upstream fb_iptables to not try to install iptables over
  and over
* Add FORWARD rules for out container forwarding
* enable/start the service

Signed-off-by: Phil Dibowitz <phil@ipom.com>
