### PR TITLE
fb_hostconf: sync with upstream

### DIFF
--- a/cookbooks/fb_hostconf/metadata.rb
+++ b/cookbooks/fb_hostconf/metadata.rb
@@ -5,7 +5,6 @@ maintainer_email 'noreply@facebook.com'
 license 'Apache-2.0'
 description 'Configures /etc/host.conf'
 source_url 'https://github.com/facebook/chef-cookbooks/'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.0.1'
 supports 'centos'
 supports 'debian'

--- a/cookbooks/fb_hostconf/recipes/default.rb
+++ b/cookbooks/fb_hostconf/recipes/default.rb
@@ -21,7 +21,7 @@
 template '/etc/host.conf' do
   only_if { node.centos? }
   source 'host.conf.erb'
-  owner 'root'
-  group 'root'
+  owner node.root_user
+  group node.root_group
   mode '0644'
 end


### PR DESCRIPTION
trivial PR, not testing

Signed-off-by: Phil Dibowitz <phil@ipom.com>
