### PR TITLE
Enable fb_hosts

### DIFF
--- a/cookbooks/fb_init/recipes/default.rb
+++ b/cookbooks/fb_init/recipes/default.rb
@@ -79,7 +79,7 @@ include_recipe 'scale_ssh'
 #include_recipe 'fb_modprobe'
 #include_recipe 'fb_securetty'
 #include_recipe 'fb_hostname'
-#include_recipe 'fb_hosts'
+include_recipe 'fb_hosts'
 #include_receip 'fb_ethers'
 # HERE: resolv
 #include_recipe 'fb_limits'


### PR DESCRIPTION
Adds public ip/name to /etc/hosts, otherwise untouched.

Tested on reg and lists (and checked web had nothing interesting in
hosts)

Signed-off-by: Phil Dibowitz <phil@ipom.com>
