### PR TITLE
enable securetty

### DIFF
--- a/cookbooks/fb_init/recipes/default.rb
+++ b/cookbooks/fb_init/recipes/default.rb
@@ -77,7 +77,7 @@ include_recipe 'scale_ssh'
 #  include_recipe 'fb_storage'
 #end
 #include_recipe 'fb_modprobe'
-#include_recipe 'fb_securetty'
+include_recipe 'fb_securetty'
 #include_recipe 'fb_hostname'
 include_recipe 'fb_hosts'
 #include_receip 'fb_ethers'


### PR DESCRIPTION
it creates `/etc/securetty` and sticks all the ttys in it

Signed-off-by: Phil Dibowitz <phil@ipom.com>
