### PR TITLE
Enable fb_syslog

### DIFF
--- a/cookbooks/fb_init/recipes/default.rb
+++ b/cookbooks/fb_init/recipes/default.rb
@@ -87,7 +87,7 @@ include_recipe 'fb_hostconf'
 include_recipe 'fb_sysctl'
 # HERE: networking
 include_recipe 'scale_users'
-#include_recipe 'fb_syslog'
+include_recipe 'fb_syslog'
 #if node.linux? && !node.container?
 #  include_recipe 'fb_hdparm'
 #  include_recipe 'fb_sdparm'

--- a/cookbooks/fb_init/recipes/site_settings.rb
+++ b/cookbooks/fb_init/recipes/site_settings.rb
@@ -153,3 +153,9 @@ package 'systemd-libs' do
   arch 'i686'
   action :remove
 end
+
+node.default['fb_syslog']['rsyslog_early_lines'] += [
+  'global(workDirectory="/var/lib/rsyslog")',
+  'module(load="imjournal", UsePid="system", FileCreateMode="0644",' +
+    ' StateFile="imjournal.state")',
+]

--- a/cookbooks/fb_syslog/README.md
+++ b/cookbooks/fb_syslog/README.md
@@ -27,6 +27,7 @@ Attributes
 * node['fb_syslog']['rsyslog_use_omprog_force']
 * node['fb_syslog']['rsyslog_stats_logging']
 * node['fb_syslog']['rsyslog_report_suspension']
+* node['fb_syslog']['rsyslog_d_preserve']
 * node['fb_syslog']['sysconfig']['vars'][$KEY][$VAL]
 * node['fb_syslog']['sysconfig']['extra_lines']
 
@@ -243,6 +244,11 @@ support it).
 Set `node['fb_syslog']['rsyslog_stats_logging']` to true to enable periodic
 output of rsyslog internal counters. These will be logged using the `impstats`
 module to `/var/log/rsyslog-stats.log`.
+
+### Controlling the syslog.d directory
+By default, we will delete everything in the `/etc/rsyslog.d`, as all rsyslog
+configuration should be controlled by users of this API. However, if you need
+to preserve such files, set `node['fb_syslog']['rsyslog_d_preserve']` to `true`.
 
 ### sysconfig settings
 On non-systemd systems, `node['fb_syslog']['sysconfig']` can be used

--- a/cookbooks/fb_syslog/attributes/default.rb
+++ b/cookbooks/fb_syslog/attributes/default.rb
@@ -35,6 +35,11 @@ syslog_file = value_for_platform_family(
   'debian' => '/var/log/syslog',
 )
 
+authlog = value_for_platform_family(
+  ['rhel', 'fedora'] => '/var/log/secure',
+  'default' => '/var/log/auth.log',
+)
+
 # Add in some reasonable defaults for all syslog.confs
 default['fb_syslog'] = {
   'syslog-entries' => {
@@ -43,8 +48,13 @@ default['fb_syslog'] = {
       'comment' => 'Log anything info level or higher. A lot ' +
                    'of things go into their own file.',
       'selector' => '*.info;mail,authpriv,cron,' +
-        'local0,local1,local2,local3,local5,local6,local7.none',
+        'local0,local1,local2,local3,local4,local5,local6,local7.none',
       'action' => "-#{syslog_file}",
+    },
+    'authlog' => {
+      'comment' => 'Log all auth stuff',
+      'selector' => 'auth,authpriv.*',
+      'action' => authlog,
     },
     'mail' => {
       'comment' => 'Log all the mail messages in one place.',
@@ -88,6 +98,7 @@ default['fb_syslog'] = {
     '$DirCreateMode 0755',
     '$Umask 0002',
   ],
+  'rsyslog_d_preserve' => false,
   'rsyslog_late_lines' => [],
   'rsyslog_additional_sockets' => [],
   'rsyslog_facilities_sent_to_remote' => [],

--- a/cookbooks/fb_syslog/recipes/default.rb
+++ b/cookbooks/fb_syslog/recipes/default.rb
@@ -73,6 +73,13 @@ template config_file do
   notifies :restart, "service[#{service_name}]"
 end
 
+directory '/etc/rsyslog.d' do
+  not_if { node['fb_syslog']['rsyslog_d_preserve'] }
+  action :delete
+  recursive true
+  notifies :restart, "service[#{service_name}]"
+end
+
 service service_name do
   action :start
   subscribes :restart, 'package[rsyslog]'

--- a/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog-kern.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog-kern.conf
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")
 

--- a/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog.conf
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")
 

--- a/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog.conf_empty
+++ b/cookbooks/fb_syslog/spec/fixtures/centos6/rsyslog.conf_empty
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")
 

--- a/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog-kern.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog-kern.conf
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 $OmitLocalLogging off
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")

--- a/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog.conf
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 $OmitLocalLogging off
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")

--- a/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog.conf_empty
+++ b/cookbooks/fb_syslog/spec/fixtures/centos7/rsyslog.conf_empty
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 $OmitLocalLogging off
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")

--- a/cookbooks/fb_syslog/spec/fixtures/centos8/rsyslog-kern.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos8/rsyslog-kern.conf
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 $OmitLocalLogging off
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")

--- a/cookbooks/fb_syslog/spec/fixtures/centos8/rsyslog.conf
+++ b/cookbooks/fb_syslog/spec/fixtures/centos8/rsyslog.conf
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 $OmitLocalLogging off
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")

--- a/cookbooks/fb_syslog/spec/fixtures/centos8/rsyslog.conf_empty
+++ b/cookbooks/fb_syslog/spec/fixtures/centos8/rsyslog.conf_empty
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 $OmitLocalLogging off
 # Provides kernel logging support (previously done by rklogd)
 module(load="imklog")

--- a/cookbooks/fb_syslog/templates/default/rsyslog.conf.erb
+++ b/cookbooks/fb_syslog/templates/default/rsyslog.conf.erb
@@ -11,7 +11,7 @@ $PreserveFQDN on
 
 #### MODULES ####
 # Provides support for local system logging (e.g. via logger command)
-$ModLoad imuxsock
+module(load="imuxsock")
 <% if node.centos? && !node.centos6? -%>
 $OmitLocalLogging off
 <% end -%>
@@ -27,8 +27,10 @@ module(load="omprog")
 <% end -%>
 <% if node['fb_syslog']['rsyslog_server'] -%>
 # UDP / TCP reception
-$ModLoad imudp
-$ModLoad imtcp
+module(load="imtcp")
+input(type="imtcp" port="514")
+module(load="imudp")
+input(type="imudp" port="514")
 
 <% if node['fb_syslog']['rsyslog_server_address'] -%>
 $UDPServerAddress <%= node['fb_syslog']['rsyslog_server_address'] %>


### PR DESCRIPTION
This pulls in changes in the pending
https://github.com/facebook/chef-cookbooks/pull/208

and then enables fb_syslog. The delta is here:

https://gist.github.com/jaymzh/d18a39b30d777d37c05a388b7cd96b59

I believe there are no *functional* changes other than preserving
full hostnames being _added_.

tested on lists and reg

Signed-off-by: Phil Dibowitz <phil@ipom.com>
