### PR TITLE
Move to fb_letsencrypt [part 1]

### DIFF
--- a/cookbooks/scale_apache/metadata.rb
+++ b/cookbooks/scale_apache/metadata.rb
@@ -7,4 +7,4 @@ source_url 'https://github.com/socallinuxexpo/scale-chef'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
 depends 'fb_apache'
-depends 'scale_certbot_hack'
+depends 'fb_letsencrypt'

--- a/cookbooks/scale_apache/recipes/certs.rb
+++ b/cookbooks/scale_apache/recipes/certs.rb
@@ -1,28 +1,3 @@
-pkgs = []
-
-pkgs << 'certbot' unless node.centos10?
-
-# undeclared dependency in c7
-pkgs << 'python-acme' if node.centos7?
-
-unless pkgs.length.zero?
-  package pkgs do
-    action :upgrade
-  end
-end
-
-# Note, web is c10 only now, but if we have to bring back
-# c9 for any reason, we'll need to bring back renew_certs.sh
-# unless we've moved to fb_letsencrypt by then
-if node.centos10?
-  include_recipe 'scale_certbot_hack'
-end
-
-node.default['fb_cron']['jobs']['renew_certs'] = {
-  'command' => '/usr/local/sbin/renew_certs.sh',
-  'time' => '1 1 * * *',
-}
-
 # in dev, we won't have a cert, so create one
 if File.exist?('/etc/httpd/need_dev_keys')
   execute 'generate dev keys' do
@@ -31,18 +6,17 @@ if File.exist?('/etc/httpd/need_dev_keys')
       ' -out /etc/httpd/apache.crt -days 999 -nodes -subj ' +
       '"/O=scale/countryName=US/commonName=www.socallinuxexpo.org"'
   end
-else
-  {
-    'apache.key' => 'privkey.pem',
-    'apache.crt' => 'cert.pem',
-    'intermediate.pem' => 'chain.pem',
-  }.each do |sslfile, path|
-    link "/etc/httpd/#{sslfile}" do
-      to lazy {
-        host = node['scale_apache']['ssl_hostname']
-        "/etc/letsencrypt/live/#{host}/#{path}"
-      }
-    end
-  end
+  return
 end
 
+include_recipe 'fb_letsencrypt'
+
+%w{crt key}.each do |type|
+  link "/etc/httpd/apache.#{type}" do
+    to lazy {
+      FB::LetsEncrypt.send(
+        type.to_sym, node, node['scale_apache']['ssl_hostname'],
+      )
+    }
+  end
+end

--- a/cookbooks/scale_reg/metadata.rb
+++ b/cookbooks/scale_reg/metadata.rb
@@ -8,4 +8,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 depends 'scale_apache'
 depends 'fb_nginx'
-depends 'scale_certbot_hack'
+depends 'fb_letsencrypt'

--- a/cookbooks/scale_reg/recipes/containerized_reg.rb
+++ b/cookbooks/scale_reg/recipes/containerized_reg.rb
@@ -28,21 +28,14 @@ include_recipe 'fb_nginx'
 
 node.default['fb_nginx']['enable_default_site'] = false
 
-include_recipe 'scale_certbot_hack'
+include_recipe 'fb_letsencrypt'
 
-# TODO: move to fb_letsencrypt
-# https://github.com/socallinuxexpo/scale-chef/issues/374
-node.default['fb_cron']['jobs']['renew_certs'] = {
-  'command' => '/usr/local/sbin/renew_certs.sh',
-  'time' => '1 1 * * *',
-}
+name = 'register.socallinuxexpo.org'
 
-link '/etc/nginx/apache.crt' do
-  to '/etc/letsencrypt/live/register.socallinuxexpo.org/fullchain.pem'
-end
-
-link '/etc/nginx/apache.key' do
-  to '/etc/letsencrypt/live/register.socallinuxexpo.org/privkey.pem'
+%w{crt key}.each do |type|
+  link "/etc/nginx/apache.#{type}" do
+    to FB::LetsEncrypt.send(type.to_sym, node, name)
+  end
 end
 
 unless ::File.exist?('/etc/nginx/apache.key')


### PR DESCRIPTION
This moves all webserver certs to fb_letsencrypt.

In a future PR I'll remove scale_certbot_hack and add some cleanup
recipes too.

Note this is built on top of #412, so both commits are in this PR, until
that is merged, click commits and view only the top one.

Signed-off-by: Phil Dibowitz <phil@ipom.com>