### PR TITLE
Fix SSL certs for web

### DIFF
--- a/cookbooks/scale_web/recipes/default.rb
+++ b/cookbooks/scale_web/recipes/default.rb
@@ -274,7 +274,6 @@ node.default['fb_apache']['sites']['_default_:443']['_rewrites'] = rewrites
   'SSLCipherSuite' => '"EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH EDH+aRSA !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS !RC4"',
   'SSLCertificateKeyFile' => '/etc/httpd/apache.key',
   'SSLCertificateFile' => '/etc/httpd/apache.crt',
-  'SSLCertificateChainFile' => '/etc/httpd/intermediate.pem',
   'FilesMatch \.(cgi|shtml|phtml|php)$' => {
     'SSLOptions' => '+StdEnvVars',
   },


### PR DESCRIPTION
fb_letsencrypt intelligently uses the chain for cert, and 'intermediate'
is not needed. This entry is a leftover that causes no problem on the
old server but also isn't used and breaks the new server.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
