### PR TITLE
Fix rsyslog syntax for newer centos

### DIFF
--- a/cookbooks/fb_init/recipes/site_settings.rb
+++ b/cookbooks/fb_init/recipes/site_settings.rb
@@ -146,6 +146,6 @@ end
 
 node.default['fb_syslog']['rsyslog_early_lines'] += [
   'global(workDirectory="/var/lib/rsyslog")',
-  'module(load="imjournal", UsePid="system", FileCreateMode="0644",' +
+  'module(load="imjournal" UsePid="system" FileCreateMode="0644"' +
     ' StateFile="imjournal.state")',
 ]


### PR DESCRIPTION
It wants spaces, not commas, in module()

Signed-off-by: Phil Dibowitz <phil@ipom.com>
