### PR TITLE
add missing directs for scale 15x-22x

### DIFF
--- a/cookbooks/scale_web/recipes/default.rb
+++ b/cookbooks/scale_web/recipes/default.rb
@@ -205,10 +205,40 @@ rewrites = {
       '%{REQUEST_URI} ^/$',
     ],
   },
+  'redirect scale23x short url to proper url' => {
+    'rule' => '^/(.*) https://www.socallinuxexpo.org/scale/23x [L,R,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale23x$',
+    ],
+  },
+  'scale 23x 2' => {
+    'rule' => '^/scale23x/(.*) https://www.socallinuxexpo.org/scale/23x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale23x/',
+    ],
+  },
+  'redirect scale22x short url to proper url' => {
+    'rule' => '^/(.*) https://www.socallinuxexpo.org/scale/21x [L,R,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale22x$',
+    ],
+  },
+  'scale 15x 2' => {
+    'rule' => '^/scale22x/(.*) https://www.socallinuxexpo.org/scale/22x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale22x/',
+    ],
+  },
   'redirect scale21x short url to proper url' => {
     'rule' => '^/(.*) https://www.socallinuxexpo.org/scale/21x [L,R,NE]',
     'conditions' => [
       '%{REQUEST_URI} ^/scale21x$',
+    ],
+  },
+  'scale 21x 2' => {
+    'rule' => '^/scale21x/(.*) https://www.socallinuxexpo.org/scale/21x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale21x/',
     ],
   },
   'redirect scale20x short url to proper url' => {
@@ -217,10 +247,22 @@ rewrites = {
       '%{REQUEST_URI} ^/scale20x$',
     ],
   },
+  'scale 20x 2' => {
+    'rule' => '^/scale20x/(.*) https://www.socallinuxexpo.org/scale/20x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale20x/',
+    ],
+  },
   'redirect scale19x short url to proper url' => {
     'rule' => '^/(.*) https://www.socallinuxexpo.org/scale/19x [L,R,NE]',
     'conditions' => [
       '%{REQUEST_URI} ^/scale19x$',
+    ],
+  },
+  'scale 19x 2' => {
+    'rule' => '^/scale19x/(.*) https://www.socallinuxexpo.org/scale/19x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale19x/',
     ],
   },
   'redirect scale18x short url to proper url' => {
@@ -229,10 +271,22 @@ rewrites = {
       '%{REQUEST_URI} ^/scale18x$',
     ],
   },
+  'scale 18x 2' => {
+    'rule' => '^/scale18x/(.*) https://www.socallinuxexpo.org/scale/18x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale18x/',
+    ],
+  },
   'redirect scale17x short url to proper url' => {
     'rule' => '^/(.*) https://www.socallinuxexpo.org/scale/17x [L,R,NE]',
     'conditions' => [
       '%{REQUEST_URI} ^/scale17x$',
+    ],
+  },
+  'scale 17x 2' => {
+    'rule' => '^/scale17x/(.*) https://www.socallinuxexpo.org/scale/17x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale17x/',
     ],
   },
   'redirect scale16x short url to proper url' => {
@@ -241,10 +295,22 @@ rewrites = {
       '%{REQUEST_URI} ^/scale16x$',
     ],
   },
+  'scale 16x 2' => {
+    'rule' => '^/scale16x/(.*) https://www.socallinuxexpo.org/scale/16x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale16x/',
+    ],
+  },
   'redirect scale15x short url to proper url' => {
     'rule' => '^/(.*) https://www.socallinuxexpo.org/scale/15x [L,R,NE]',
     'conditions' => [
       '%{REQUEST_URI} ^/scale15x$',
+    ],
+  },
+  'scale 15x 2' => {
+    'rule' => '^/scale15x/(.*) https://www.socallinuxexpo.org/scale/15x/$1 [L,R=301,NE]',
+    'conditions' => [
+      '%{REQUEST_URI} ^/scale15x/',
     ],
   },
   'scale 14x' => {


### PR DESCRIPTION
### What does this PR do?

add missing redirects for /scale${edition} for 15x-23x 

### Motivation

consistency

### Testing Guidelines

go to www.socallinuxexpo.org/scale22x and /scale22x/ and confirm it redirects to /scale/22x/ 