### PR TITLE
reg: Add SCALEREG_EXPRESS_CHECKIN_SECRET to settings

### DIFF
--- a/cookbooks/scale_reg/templates/settings.py.erb
+++ b/cookbooks/scale_reg/templates/settings.py.erb
@@ -117,6 +117,9 @@ SCALEREG_PAYFLOW_LOGIN = 'usclug'
 # Partner (either Paypal or Verisign):
 SCALEREG_PAYFLOW_PARTNER = 'verisign'
 
+# Secret used for express check-in and scanned badges.
+SCALEREG_EXPRESS_CHECKIN_SECRET = '<%= node['fb_init']['secrets']['reg_checkin_secret_key'] %>'
+
 # Set to True if you want scalereg to be able to email attendees.
 # You need to set EMAIL_HOST, EMAIL_PORT, and other EMAIL_ settings
 # appropriately.


### PR DESCRIPTION
### What does this PR do?

Update settings.py to populate the setting https://github.com/socallinuxexpo/scalereg/pull/79 added.

### Motivation

Make sure express check-in codes are salted with something other than a blank string.