### PR TITLE
scale-web: exclude PHP 8.4

### DIFF
--- a/cookbooks/scale_web/recipes/default.rb
+++ b/cookbooks/scale_web/recipes/default.rb
@@ -318,6 +318,7 @@ node.default['fb_apache']['sites']['_default_:443']['_rewrites'] = rewrites
   node.default['fb_apache']['sites']['_default_:443'][key] = val
 end
 
+node.default['fb_dnf']['config']['main']['exclude'] = 'php8.4*'
 pkgs = %w{
   git
   python3-boto3


### PR DESCRIPTION
We may want to move to 8.4, but probably not accidentally. :)

This fixes Chef on scale-web

Signed-off-by: Phil Dibowitz <phil@ipom.com>
