### PR TITLE
lists: Fix STARTTLS for postfix

### DIFF
--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -22,7 +22,14 @@ node.default['fb_postfix']['main.cf']['inet_interfaces'] = "all"
   node.default['fb_postfix']['main.cf'][conf] = val
 end
 
-node.default['fb_postfix']['main.cf']['smtpd_tls_security_level'] = 'may'
+hname = "lists.socallinuxexpo.org"
+{
+  'smtpd_tls_cert_file' => FB::LetsEncrypt.cert(node, hname),
+  'smtpd_tls_key_file' => FB::LetsEncrypt.key(node, hname),
+  'smtpd_tls_security_level' => 'may',
+}.each do |conf, val|
+  node.default['fb_postfix']['main.cf'][conf] = val
+end
 
 include_recipe '::mailman3'
 


### PR DESCRIPTION
```
$ telnet lists.linuxfests.org 25
Trying 2600:1f18:1a34:e402:2eef:927e:e25b:2215...
Connected to lists.linuxfests.org.
Escape character is '^]'.
220 scale-lists-centos9.linuxfests.org ESMTP
EHLO ipom
250-scale-lists-centos9.linuxfests.org
250-PIPELINING
250-SIZE 10240000
250-ETRN
250-STARTTLS
250-ENHANCEDSTATUSCODES
250-8BITMIME
250-DSN
250 CHUNKING
STARTTLS
220 2.0.0 Ready to start TLS
```

Signed-off-by: Phil Dibowitz <phil@ipom.com>
