### PR TITLE
Mailman: handle DKIM/ARC headers better

### DIFF
--- a/cookbooks/fb_postfix/templates/default/custom_headers.regexp.erb
+++ b/cookbooks/fb_postfix/templates/default/custom_headers.regexp.erb
@@ -4,6 +4,10 @@
 <% custom_headers = node['fb_postfix']['custom_headers'].to_hash %>
 <% custom_headers.keys.sort.each do |name| %>
 <%   hdr = node['fb_postfix']['custom_headers'][name] %>
+<%   line = "#{hdr['regexp']} #{hdr['action']}" %>
+<%   if hdr['header'] %>
+<%     line += " #{hdr['header']}: #{hdr['value']}" %>
+<%   end %>
 # Name: <%= name %>
-<%=  hdr['regexp'] %> <%= hdr['action'] %> <%= hdr['header'] %>: <%= hdr['value'] %>
+<%=  line %>
 <% end %>

--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -31,6 +31,21 @@ hname = "lists.socallinuxexpo.org"
   node.default['fb_postfix']['main.cf'][conf] = val
 end
 
+# Mailgun will re-sign our messages, but strip incoming signatures,
+# because it causes some confusion.
+{
+  'strip incoming ARC headers' => {
+    'regexp' => '/^ARC-.*:/',
+    'action' => 'IGNORE',
+  },
+  'strip incoming DKIM headers' => {
+    'regexp' => '/^DKIM-Signature:/',
+    'action' => 'IGNORE',
+  },
+}.each do |name, conf|
+  node.default['fb_postfix']['custom_headers'][name] = conf
+end
+
 include_recipe '::mailman3'
 
 # some common stuff - backups, monitoring, service


### PR DESCRIPTION
Strip incoming ARC and DKIM headers since we KNOW we're going to
munge messages. We will re-sign them in mailgun, which will thus
pass DMARC.

Sent upstream fix here: https://github.com/facebook/chef-cookbooks/pull/352

Signed-off-by: Phil Dibowitz <phil@ipom.com>
