### PR TITLE
Nuke phplist

### DIFF
--- a/cookbooks/scale_phplist/recipes/cleanup.rb
+++ b/cookbooks/scale_phplist/recipes/cleanup.rb
@@ -1,0 +1,19 @@
+
+Dir.glob("/usr/local/phplist-*").each do |dir|
+  directory dir do
+    recursive true
+    action :delete
+  end
+end
+
+file '/usr/local/sbin/phplist_wrapper' do
+  action :delete
+end
+
+pkgs = [
+  'php', 'php-mysqlnd', 'php-imap', 'remi-release-9'
+]
+
+package pkgs do
+  action :remove
+end

--- a/roles/lists.rb
+++ b/roles/lists.rb
@@ -1,5 +1,5 @@
 name "lists"
 run_list [
   "recipe[scale_mailman]",
-  "recipe[scale_phplist]",
+  "recipe[scale_phplist::cleanup]",
 ]


### PR DESCRIPTION
A follow-up PR can remove the cookbook, but we need to do cleanup first.

Closes: #445

Signed-off-by: Phil Dibowitz <phil@ipom.com>
