### PR TITLE
Drupal: Let's encrypt traffic to the DB - starting with staging

### DIFF
--- a/cookbooks/scale_drupal/metadata.rb
+++ b/cookbooks/scale_drupal/metadata.rb
@@ -6,3 +6,4 @@ description 'Installs/Configures SCAPE Drupal setup'
 source_url 'https://github.com/socallinuxexpo/scale-chef'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.1.0'
+depends 'scale_misc'

--- a/cookbooks/scale_drupal/recipes/default.rb
+++ b/cookbooks/scale_drupal/recipes/default.rb
@@ -23,6 +23,8 @@ package 'awscli2' do
   action :upgrade
 end
 
+include_recipe 'scale_misc::rds_cert'
+
 cookbook_file '/usr/local/bin/deploy_site' do
   source 'deploy_site'
   owner 'root'

--- a/cookbooks/scale_drupal/templates/default/settings-drupal10.php.erb
+++ b/cookbooks/scale_drupal/templates/default/settings-drupal10.php.erb
@@ -46,6 +46,13 @@ $databases['default']['default'] = [
   'prefix' => '',
 ];
 
+<% if node['hostname'] == 'scale-web-centos10-staging' %>
+$databases['default']['default']['pdo'] = [
+  PDO::MYSQL_ATTR_SSL_CA => '/etc/ssl/certs/rds-combined-ca-bundle.pem',
+  PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => true,
+];
+<% end %>
+
 /**
  * Salt for one-time login links, cancel links, form tokens, etc.
  *
@@ -65,4 +72,3 @@ $databases['default']['default'] = [
  * @endcode
  */
 $settings['hash_salt'] = '<%= node['fb_init']['secrets']['drupal_hash_salt'] %>';
-

--- a/cookbooks/scale_misc/README.md
+++ b/cookbooks/scale_misc/README.md
@@ -1,0 +1,15 @@
+scale_misc Cookbook
+===================
+A set of misc recipes
+
+Requirements
+------------
+
+Attributes
+----------
+
+Usage
+-----
+### rds_cert
+
+Download and install the global CA cert for RDS.

--- a/cookbooks/scale_misc/attributes/default.rb
+++ b/cookbooks/scale_misc/attributes/default.rb
@@ -1,0 +1,2 @@
+default['scale_misc'] = {
+}

--- a/cookbooks/scale_misc/metadata.rb
+++ b/cookbooks/scale_misc/metadata.rb
@@ -1,0 +1,7 @@
+name 'scale_misc'
+maintainer 'SCALE'
+maintainer_email 'phil@ipom.com'
+license 'All Rights Reserved'
+description 'Misc recipes for Scale'
+version '0.1.0'
+chef_version '>= 15.0'

--- a/cookbooks/scale_misc/recipes/rds_cert.rb
+++ b/cookbooks/scale_misc/recipes/rds_cert.rb
@@ -1,0 +1,6 @@
+remote_file '/etc/ssl/certs/rds-combined-ca-bundle.pem' do
+  source 'https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end


### PR DESCRIPTION
@DrupalPhil - After this rolls out I'll have you confirm things
look good, then set the `require_secure_transport` on the staging DB.

Then we can do this on the prod db.

First PR in #21

Signed-off-by: Phil Dibowitz <phil@ipom.com>
