### PR TITLE
Stop stripping headers on lists server

### DIFF
--- a/cookbooks/scale_mailman/recipes/default.rb
+++ b/cookbooks/scale_mailman/recipes/default.rb
@@ -33,21 +33,6 @@ hname = "lists.socallinuxexpo.org"
   node.default['fb_postfix']['main.cf'][conf] = val
 end
 
-# Mailgun will re-sign our messages, but strip incoming signatures,
-# because it causes some confusion.
-{
-  'strip incoming ARC headers' => {
-    'regexp' => '/^ARC-.*:/',
-    'action' => 'IGNORE',
-  },
-  'strip incoming DKIM headers' => {
-    'regexp' => '/^DKIM-Signature:/',
-    'action' => 'IGNORE',
-  },
-}.each do |name, conf|
-  node.default['fb_postfix']['custom_headers'][name] = conf
-end
-
 include_recipe '::mailman3'
 
 # some common stuff - backups, monitoring, service


### PR DESCRIPTION
I don't believe this is necessary and it's a bit ugly to do
if it's not required.

Now that mailgun is setup properly for domains, our DMARC has
moved to 100% compliance.

Signed-off-by: Phil Dibowitz <phil@ipom.com>
