### PR TITLE
More pd_lsecrets migration

### DIFF
--- a/cookbooks/fb_init/attributes/default.rb
+++ b/cookbooks/fb_init/attributes/default.rb
@@ -11,6 +11,7 @@ tier = pieces[1]
 default['tier'] = tier
 default['env'] = env
 
+# Deprecated...
 d = {}
 if File.exist?('/etc/chef_secrets')
   File.read('/etc/chef_secrets').each_line do |line|

--- a/cookbooks/scale_datadog/recipes/dd-handler.rb
+++ b/cookbooks/scale_datadog/recipes/dd-handler.rb
@@ -20,7 +20,7 @@
 
 require 'uri'
 
-unless node['fb_init']['secrets']['datadog_api_key']
+unless node['scale_datadog']['config']['api_key']
   Chef::Log.warn('No Datadog secrets available, skipping datadog setup')
   return
 end
@@ -32,8 +32,8 @@ end
 require 'chef/handler/datadog'
 
 handler_config = {
-  :api_key => node['fb_init']['secrets']['datadog_api_key'],
-  :application_key => node['fb_init']['secrets']['datadog_application_key'],
+  :api_key => node['scale_datadog']['config']['api_key'],
+  :application_key => node['scale_datadog']['config']['application_key'],
   :tag_prefix => 'tag:',
 }
 

--- a/cookbooks/scale_datadog/recipes/default.rb
+++ b/cookbooks/scale_datadog/recipes/default.rb
@@ -51,6 +51,6 @@ service 'datadog-agent' do
   # the normal ruby-stile exist-and-not-nil check makes Chef warn because a
   # string is returned inside of it, and it thinks you are trying to use a
   # shell-command-style only_if
-  not_if { node['fb_init']['secrets']['datadog_api_key'].nil? }
+  not_if { node['scale_datadog']['config']['api_key'].nil? }
   action [:enable, :start]
 end

--- a/cookbooks/scale_drupal/templates/default/backup-drupal-static3.sh.erb
+++ b/cookbooks/scale_drupal/templates/default/backup-drupal-static3.sh.erb
@@ -6,8 +6,8 @@ DATE=`date +%Y/%m/%d`
 TIME=`date +%H-%M-%S`
 TARGET="drupal-static_${HOSTNAME}_${TIME}.tar.gz"
 
-export AWS_ACCESS_KEY_ID="<%= node['fb_init']['secrets']['s3_aws_access_key_id'] %>"
-export AWS_SECRET_ACCESS_KEY="<%= node['fb_init']['secrets']['s3_aws_secret_access_key'] %>"
+export AWS_ACCESS_KEY_ID="<%= node['pd_lsecrets']['s3_aws_access_key_id'] %>"
+export AWS_SECRET_ACCESS_KEY="<%= node['pd_lsecrets']['s3_aws_secret_access_key'] %>"
 
 echo "Starting backup...."
 tar cfz $TMPFILE/${TARGET} -C /home/drupal/scale-drupal/httpdocs/sites/default/ files


### PR DESCRIPTION
* mark old secrets as deprecated
* make scale_datadog look at it's own config for keys
* Migrate drupal backups

Tested on web, no delta

Signed-off-by: Phil Dibowitz <phil@ipom.com>
